### PR TITLE
Fix dependency paths, use node modules over local `/lib`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -861,10 +861,11 @@
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-      "dev": true
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "optional": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -1199,22 +1200,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.0-next.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
-      "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
+      "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.0",
-        "string.prototype.trimright": "^2.1.0"
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
       }
     },
     "es-to-primitive": {
@@ -1255,9 +1256,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.7.2.tgz",
-      "integrity": "sha512-qMlSWJaCSxDFr8fBPvJM9kJwbazrhNcBU3+DszDW1OlEwKBBRWsJc7NJFelvwQpanHCR14cOLD41x8Eqvo3Nng==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1821,6 +1822,14 @@
       "dev": true,
       "requires": {
         "find-file-up": "^2.0.1"
+      }
+    },
+    "find-pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-pkg-dir/-/find-pkg-dir-2.0.0.tgz",
+      "integrity": "sha512-FQSkqcdGa2Rsg2ismCcS5v/mf6ieB0RcOBQhIEWurusYkIZRpKnumugzdbCqKZXsbCUdkni7aoIgpUXRL+HrxQ==",
+      "requires": {
+        "inspect-with-kind": "^1.0.5"
       }
     },
     "find-root": {
@@ -3093,6 +3102,12 @@
         "supports-color": "5.4.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -5095,15 +5110,6 @@
       "requires": {
         "commander": "~2.20.3",
         "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "unherit": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     ]
   },
   "dependencies": {
+    "find-pkg-dir": "^2.0.0",
     "kind-of": "^6.0.2",
     "lodash": "^4.17.15",
     "path-is-inside": "^1.0.2",

--- a/server.js
+++ b/server.js
@@ -2,10 +2,10 @@
 
 const { join, parse } = require('path');
 
-const findPkgDir = require('./lib/find-pkg-dir');
+const findPkgDir = require('find-pkg-dir');
 const parseUri = require('vscode-uri').URI.parse;
 const pathIsInside = require('path-is-inside');
-const stylelintVSCode = require('./lib/stylelint-vscode');
+const stylelintVSCode = require('stylelint-vscode');
 const { createConnection, ProposedFeatures, TextDocuments } = require('vscode-languageserver');
 
 let config;


### PR DESCRIPTION
This PR reverts the following two changes:

https://github.com/stylelint/vscode-stylelint/commit/72fcb115ef8f13322e413567ae74815ab8c1614b#diff-78c12f5adc1848d13b1c6f07055d996eR8

> From: `const stylelintVSCode = require('./lib/stylelint-vscode');`
> To: `const stylelintVSCode = require('stylelint-vscode');`


https://github.com/stylelint/vscode-stylelint/commit/d978bda254ff5e3265ed4b43a9491360aec6c5b3#diff-78c12f5adc1848d13b1c6f07055d996eR5

> From: `const findPkgDir = require('./lib/find-pkg-dir');`
> To: `const findPkgDir = require('find-pkg-dir');`

It also adds back installs the `find-pkg-dir` as dependency

----

The reasoning for this is that when publishing the VS Code extension the `./lib` folder is not included in the published extension.

The above issues can be resolved once #21 is completed
