### PR TITLE
A slightly stricter install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A [Visual Studio Code](https://code.visualstudio.com/) extension to lint [CSS](h
 ## Installation
 
 1. Execute `Extensions: Install Extensions` command from [Command Palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette).
-2. Type `stylelint.vscode-stylelint` into the search form and install the topmost one.
+2. Type `@id:stylelint.vscode-stylelint` into the search form and install the topmost one.
 
 Read the [extension installation guide](https://code.visualstudio.com/docs/editor/extension-gallery) for more details.
 


### PR DESCRIPTION
A slightly annoying follow up from my prior PR. I just found out that you can search for an extension with a specific ID - this'll avoid accidentally finding other extensions that keyword stuff their descriptions (which nothing does currently but whatever)