### PR TITLE
feat: Add `stylelint-disable` snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "theme": "dark"
   },
   "categories": [
-    "Linters"
+    "Linters",
+    "Snippets"
   ],
   "keywords": [
     "css",
@@ -116,6 +117,20 @@
         "filenames": [
           ".stylelintignore"
         ]
+      }
+    ],
+    "snippets": [
+      {
+        "language": "css",
+        "path": "./snippets/stylelint-disable.json"
+      },
+      {
+        "language": "postcss",
+        "path": "./snippets/stylelint-disable.json"
+      },
+      {
+        "language": "scss",
+        "path": "./snippets/stylelint-disable.json"
       }
     ]
   },

--- a/snippets/stylelint-disable.json
+++ b/snippets/stylelint-disable.json
@@ -1,0 +1,17 @@
+{
+	"stylelint-disable": {
+		"prefix": "stylelint-disable",
+		"body": ["/* stylelint-disable ${1:rule} */", "$0/* stylelint-enable ${1:rule} */"],
+		"description": "Turn off all stylelint or individual rules, after which you do not need to re-enable stylelint."
+	},
+	"stylelint disable line": {
+		"prefix": "stylelint-disable-line",
+		"body": ["/* stylelint-disable-line ${0:rule} */"],
+		"description": "Turn off stylelint rules for individual lines only, after which you do not need to explicitly re-enable them."
+	},
+	"stylelint-disable-next-line": {
+		"prefix": "stylelint-disable-next-line",
+		"body": ["/* stylelint-disable-next-line ${0:rule} */"],
+		"description": "Turn off stylelint rules for the next line only, after which you do not need to explicitly re-enable them."
+	}
+}

--- a/snippets/stylelint-disable.json
+++ b/snippets/stylelint-disable.json
@@ -4,7 +4,7 @@
 		"body": ["/* stylelint-disable ${1:rule} */", "$0/* stylelint-enable ${1:rule} */"],
 		"description": "Turn off all stylelint or individual rules, after which you do not need to re-enable stylelint."
 	},
-	"stylelint disable line": {
+	"stylelint-disable-line": {
 		"prefix": "stylelint-disable-line",
 		"body": ["/* stylelint-disable-line ${0:rule} */"],
 		"description": "Turn off stylelint rules for individual lines only, after which you do not need to explicitly re-enable them."

--- a/snippets/stylelint-disable.test.js
+++ b/snippets/stylelint-disable.test.js
@@ -2,7 +2,7 @@
 
 const snippets = require('./stylelint-disable.json');
 
-const unique = xs => [...new Set(xs)];
+const unique = (xs) => [...new Set(xs)];
 
 describe('Snippets', () => {
 	const keys = Object.keys(snippets);
@@ -17,17 +17,15 @@ describe('Snippets', () => {
 		expect(keys).toEqual(sortedKeys);
 	});
 
-	it("has unique prefixes", () => {
-		const prefixes = Object.values(snippets).map(x => x.prefix);
+	it('has unique prefixes', () => {
+		const prefixes = Object.values(snippets).map((x) => x.prefix);
 
 		expect(prefixes).toEqual(unique(prefixes));
 	});
 
 	describe.each(keys)('%s', (key) => {
 		it('should have a prefix', () => {
-			const {
-				prefix
-			} = snippets[key];
+			const { prefix } = snippets[key];
 
 			expect(prefix).toBeDefined();
 			expect(prefix.length).toBeGreaterThan(0);
@@ -35,18 +33,14 @@ describe('Snippets', () => {
 		});
 
 		it('should have a body', () => {
-			const {
-				body
-			} = snippets[key];
+			const { body } = snippets[key];
 
 			expect(body).toBeDefined();
 			expect(body.length).toBeGreaterThan(0);
 		});
 
 		it('should have a description', () => {
-			const {
-				description
-			} = snippets[key];
+			const { description } = snippets[key];
 
 			expect(description).toBeDefined();
 			expect(description.length).toBeGreaterThan(0);

--- a/snippets/stylelint-disable.test.js
+++ b/snippets/stylelint-disable.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const snippets = require('./stylelint-disable.json');
+
+const unique = xs => [...new Set(xs)];
+
+describe('Snippets', () => {
+	const keys = Object.keys(snippets);
+
+	it('should not be empty', () => {
+		expect(keys.length).toBeGreaterThan(0);
+	});
+
+	it('is sorted by key', () => {
+		const sortedKeys = [...keys].sort();
+
+		expect(keys).toEqual(sortedKeys);
+	});
+
+	it("has unique prefixes", () => {
+		const prefixes = Object.values(snippets).map(x => x.prefix);
+
+		expect(prefixes).toEqual(unique(prefixes));
+	});
+
+	describe.each(keys)('%s', (key) => {
+		it('should have a prefix', () => {
+			const {
+				prefix
+			} = snippets[key];
+
+			expect(prefix).toBeDefined();
+			expect(prefix.length).toBeGreaterThan(0);
+			expect(prefix.startsWith('stylelint-disable')).toBe(true);
+		});
+
+		it('should have a body', () => {
+			const {
+				body
+			} = snippets[key];
+
+			expect(body).toBeDefined();
+			expect(body.length).toBeGreaterThan(0);
+		});
+
+		it('should have a description', () => {
+			const {
+				description
+			} = snippets[key];
+
+			expect(description).toBeDefined();
+			expect(description.length).toBeGreaterThan(0);
+		});
+	});
+});


### PR DESCRIPTION
This pull request seeks to add the 3 available _stylelint-disable_ snippets

Support is added for CSS, PostCSS, and SCSS

• `/* stylelint-disable */`/`/* stylelint-enable */`
• `/* stylelint-disable-line */`
• `/* stylelint-disable-next-line rule */`