### PR TITLE
Add "stylelint.stylelintPath" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ e.g.
   "stylelint.customSyntax": "${workspaceFolder}/custom-syntax.js"
 ```
 
+#### stylelint.stylelintPath
+
+Type: `string`  
+Default: `""`
+
+Supply a custom path to the stylelint module.
+
 #### stylelint.packageManager
 
 Type: `"npm" | "yarn" | "pnpm"`  

--- a/lib/stylelint-vscode/index.js
+++ b/lib/stylelint-vscode/index.js
@@ -164,12 +164,34 @@ module.exports = async function stylelintVSCode(textDocument, options = {}, serv
 	return processResults(resultContainer);
 };
 
-async function lint(options, { connection, packageManager, textDocument }) {
+async function lint(
+	options,
+	{ connection, packageManager, stylelintPath: customStylelintPath, textDocument },
+) {
 	function trace(message, verbose) {
 		connection.tracer.log(message, verbose);
 	}
 
 	let stylelint;
+
+	if (customStylelintPath) {
+		try {
+			stylelint = require(customStylelintPath);
+		} catch (err) {
+			connection.window.showErrorMessage(
+				`stylelint: cannot resolve "stylelintPath": ${customStylelintPath}`,
+			);
+			throw err;
+		}
+
+		if (stylelint && typeof stylelint.lint === 'function') {
+			return await stylelint.lint(options);
+		}
+
+		connection.window.showErrorMessage(
+			`stylelint: cannot resolve "stylelintPath": ${customStylelintPath}`,
+		);
+	}
 
 	try {
 		const resolvedGlobalPackageManagerPath = globalPathGet(packageManager, trace);

--- a/lib/stylelint-vscode/test/fake-stylelint.js
+++ b/lib/stylelint-vscode/test/fake-stylelint.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+	lint() {
+		return {
+			results: [
+				{
+					warnings: [
+						{
+							line: 1,
+							column: 1,
+							rule: 'fake',
+							text: 'Fake result',
+							severity: 'error',
+						},
+					],
+					invalidOptionWarnings: [],
+				},
+			],
+		};
+	},
+};

--- a/lib/stylelint-vscode/test/test.js
+++ b/lib/stylelint-vscode/test/test.js
@@ -643,3 +643,59 @@ test('stylelintVSCode() with customSyntax', async (t) => {
 		);
 	})();
 });
+
+test('stylelintVSCode() with stylelintPath', async (t) => {
+	t.plan(2);
+
+	(async () => {
+		t.deepEqual(
+			await stylelintVSCode(
+				new Document('test.css', 'css', 'a{\n   color:red}'),
+				{
+					config: { rules: { indentation: [2] } },
+				},
+				{
+					stylelintPath: resolve(__dirname, '../../../node_modules/stylelint'),
+				},
+			),
+			{
+				diagnostics: [
+					{
+						range: { start: { line: 1, character: 3 }, end: { line: 1, character: 3 } },
+						message: 'Expected indentation of 2 spaces (indentation)',
+						severity: 1,
+						code: 'indentation',
+						source: 'stylelint',
+					},
+				],
+			},
+			'should work properly if stylelintPath is defined.',
+		);
+	})();
+
+	(async () => {
+		t.deepEqual(
+			await stylelintVSCode(
+				new Document('test.css', 'css', 'a{\n   color:red}'),
+				{
+					config: { rules: { indentation: [2] } },
+				},
+				{
+					stylelintPath: require.resolve('./fake-stylelint'),
+				},
+			),
+			{
+				diagnostics: [
+					{
+						range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+						code: 'fake',
+						message: 'Fake result',
+						severity: 1,
+						source: 'stylelint',
+					},
+				],
+			},
+			'should work properly if custom path is defined in stylelintPath.',
+		);
+	})();
+});

--- a/package.json
+++ b/package.json
@@ -90,6 +90,11 @@
           "default": "",
           "description": "An absolute path to a custom PostCSS-compatible syntax module."
         },
+        "stylelint.stylelintPath": {
+          "type": "string",
+          "default": "",
+          "description": "Supply a custom path to the stylelint module."
+        },
         "stylelint.packageManager": {
           "scope": "resource",
           "type": "string",

--- a/test/ws-stylelint-path-test/.vscode/settings.json
+++ b/test/ws-stylelint-path-test/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"stylelint.stylelintPath": "fake-stylelint.js"
+}

--- a/test/ws-stylelint-path-test/fake-stylelint.js
+++ b/test/ws-stylelint-path-test/fake-stylelint.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+	lint() {
+		return {
+			results: [
+				{
+					warnings: [
+						{
+							line: 1,
+							column: 1,
+							rule: 'fake',
+							text: 'Fake result',
+							severity: 'error',
+						},
+					],
+					invalidOptionWarnings: [],
+				},
+			],
+		};
+	},
+};

--- a/test/ws-stylelint-path-test/index.js
+++ b/test/ws-stylelint-path-test/index.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const path = require('path');
+const pWaitFor = require('p-wait-for');
+const test = require('tape');
+const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
+
+const run = () =>
+	test('vscode-stylelint with "stylelint.stylelintPath"', async (t) => {
+		await commands.executeCommand('vscode.openFolder', Uri.file(__dirname));
+
+		const vscodeStylelint = extensions.getExtension('stylelint.vscode-stylelint');
+
+		// Open the './test.css' file.
+		const cssDocument = await workspace.openTextDocument(path.resolve(__dirname, 'test.css'));
+
+		await window.showTextDocument(cssDocument);
+
+		// Wait for diagnostics result.
+		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
+		await pWaitFor(() => languages.getDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+
+		// Check the result.
+		const diagnostics = languages.getDiagnostics(cssDocument.uri);
+
+		t.deepEqual(
+			diagnostics.map((o) => ({ ...o, range: normalizeRange(o.range) })),
+			[
+				{
+					range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+					code: 'fake',
+					message: 'Fake result',
+					severity: 0,
+					source: 'stylelint',
+				},
+			],
+			'should work even if "stylelint.stylelintPath" is defined.',
+		);
+
+		t.end();
+	});
+
+exports.run = (root, done) => {
+	test.onFinish(done);
+	run();
+};
+
+function normalizeRange(range) {
+	const obj = {
+		start: {
+			line: range.start.line,
+			character: range.start.character,
+		},
+	};
+
+	if (range.end !== undefined) {
+		obj.end = {
+			line: range.end.line,
+			character: range.end.character,
+		};
+	}
+
+	return obj;
+}

--- a/test/ws-stylelint-path-test/stylelint.config.js
+++ b/test/ws-stylelint-path-test/stylelint.config.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+	rules: {
+		indentation: [4],
+	},
+};

--- a/test/ws-stylelint-path-test/test.css
+++ b/test/ws-stylelint-path-test/test.css
@@ -1,0 +1,1 @@
+/* prettier-ignore */


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Related to #44.

> Is there anything in the PR that needs further explanation?

This PR adds `"stylelint.stylelintPath"` option.
The `stylelint.stylelintPath` option is similar to the [`prettier.prettierPath`](https://github.com/prettier/prettier-vscode#prettierprettierpath) option of `prettier-vscode`.
By setting the stylelint module path in the `stylelint.stylelintPath` option, the stylelint module selected by the user can be used with this extension.

The main purpose of the `stylelint.stylelintPath` option is to solve problems when used with Yarn 2. I tested CSS in the Yarn 2 environment and it worked.
However, it did not work with SCSS. This is probably another issue, as it did not work with the CLI. 
(I'm not familiar with Yarn, so my environment could be the cause.)


