### PR TITLE
Include snippets for Less files

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,10 @@
         "path": "./snippets/stylelint-disable.json"
       },
       {
+        "language": "less",
+        "path": "./snippets/stylelint-disable.json"
+      },
+      {
         "language": "postcss",
         "path": "./snippets/stylelint-disable.json"
       },


### PR DESCRIPTION
This PR updates the _snippets_ extension config so that the _stylelint-disable_ disable snippets are also available with Less files