### PR TITLE
Remove `editor.codeActionsOnSaveTimeout` reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,6 @@ You can also selectively enable and disable specific languages using VS Code's l
   }
 ```
 
-Also note that there is a time budget of 750ms to run code actions on save which might not be enough for large files. You can increase the time budget using the `editor.codeActionsOnSaveTimeout` setting.
-
 ### Commands
 
 This extension contributes the following commands to the Command palette.


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

See #45 https://github.com/stylelint/vscode-stylelint/issues/45#issuecomment-586624419

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self explanatory."
