### PR TITLE
Add "stylelint.reportNeedlessDisables" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ e.g.
   "stylelint.customSyntax": "${workspaceFolder}/custom-syntax.js"
 ```
 
+#### stylelint.reportNeedlessDisables
+
+Type: `boolean`  
+Default: `false`
+
+Set stylelint [`reportNeedlessDisables`](https://stylelint.io/user-guide/node-api#reportneedlessdisables) option. If `true`, also report errors for `stylelint-disable` comments that are not blocking a lint warning.
+
 #### stylelint.stylelintPath
 
 Type: `string`  

--- a/lib/stylelint-vscode/index.js
+++ b/lib/stylelint-vscode/index.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const pathIsInside = require('path-is-inside');
 const { at, has, intersection, isPlainObject, map, stubString } = require('lodash');
+const { Diagnostic, DiagnosticSeverity, Position, Range } = require('vscode-languageserver-types');
 const { execSync } = require('child_process');
 const { Files, TextDocument } = require('vscode-languageserver');
 const { URI } = require('vscode-uri');
@@ -11,6 +12,10 @@ const arrayToError = require('../array-to-error');
 const arrayToSentence = require('../array-to-sentence');
 const inspectWithKind = require('../inspect-with-kind');
 const stylelintWarningToVscodeDiagnostic = require('../stylelint-warning-to-vscode-diagnostic');
+
+/**
+ * @typedef { {unusedRule:string,start:number,end:?number} } DisableReportRange
+ */
 
 // https://github.com/stylelint/stylelint/blob/12.0.1/lib/getPostcssResult.js#L82-L88
 const SUPPORTED_SYNTAXES = new Set([
@@ -43,11 +48,17 @@ function quote(str) {
 	return `\`${str}\``;
 }
 
-function processResults(resultContainer) {
-	const { results } = resultContainer;
+/**
+ *
+ * @param {*} resultContainer
+ * @param {*} textDocument
+ * @returns { { diagnostics: Diagnostic[], output?: string, needlessDisables?: ({ diagnostic: Diagnostic, range: DisableReportRange })[] } }
+ */
+function processResults(resultContainer, textDocument) {
+	const { results, needlessDisables } = resultContainer;
 
 	// https://github.com/stylelint/stylelint/blob/12.0.1/lib/standalone.js#L128-L134
-	if (results.length === 0) {
+	if (results.length === 0 && (!needlessDisables || needlessDisables.length === 0)) {
 		return {
 			diagnostics: [],
 		};
@@ -65,17 +76,38 @@ function processResults(resultContainer) {
 		throw arrayToError(map(invalidOptionWarnings, 'text'), SyntaxError);
 	}
 
-	const diagnostics = warnings.map(stylelintWarningToVscodeDiagnostic);
+	const diagnostics = [];
+	let needlessDisableResults;
+
+	const needlessDisableSourceReport = needlessDisables && needlessDisables[0];
+
+	if (needlessDisableSourceReport) {
+		needlessDisableResults = [];
+
+		for (const range of needlessDisableSourceReport.ranges) {
+			const diagnostic = stylelintDisableOptionsReportRangeToVscodeDiagnostic(range, textDocument);
+
+			diagnostics.push(diagnostic);
+			needlessDisableResults.push({
+				range,
+				diagnostic,
+			});
+		}
+	}
+
+	diagnostics.push(...warnings.map(stylelintWarningToVscodeDiagnostic));
 
 	if (has(resultContainer, 'output') && resultContainer.output) {
 		return {
 			diagnostics,
 			output: resultContainer.output,
+			...(needlessDisableResults ? { needlessDisables: needlessDisableResults } : {}),
 		};
 	}
 
 	return {
 		diagnostics,
+		...(needlessDisableResults ? { needlessDisables: needlessDisableResults } : {}),
 	};
 }
 
@@ -161,7 +193,7 @@ module.exports = async function stylelintVSCode(textDocument, options = {}, serv
 		throw err;
 	}
 
-	return processResults(resultContainer);
+	return processResults(resultContainer, textDocument);
 };
 
 async function lint(
@@ -287,4 +319,38 @@ function globalPathGet(packageManager, trace) {
 	}
 
 	return undefined;
+}
+
+/**
+ * @param {DisableReportRange} range
+ * @param {TextDocument} textDocument
+ */
+function stylelintDisableOptionsReportRangeToVscodeDiagnostic(range, textDocument) {
+	let message = `unused rule: ${range.unusedRule}, start line: ${range.start}`;
+	const startPosition = convertStartPosition(range);
+	const endPosition = convertEndPosition(range, textDocument);
+
+	if (range.end !== undefined) {
+		message += `, end line: ${range.end}`;
+	}
+
+	return Diagnostic.create(
+		Range.create(startPosition, endPosition),
+		message,
+		DiagnosticSeverity.Warning,
+		range.unusedRule,
+		'stylelint',
+	);
+}
+
+function convertStartPosition(range) {
+	return Position.create(range.start - 1, 0);
+}
+
+function convertEndPosition(range, textDocument) {
+	if (range.end) {
+		return textDocument.positionAt(textDocument.offsetAt(Position.create(range.end, 0)) - 1);
+	} else {
+		return textDocument.positionAt(textDocument.getText().length);
+	}
 }

--- a/lib/stylelint-vscode/test/test.js
+++ b/lib/stylelint-vscode/test/test.js
@@ -688,6 +688,128 @@ test('stylelintVSCode() with customSyntax', async (t) => {
 	})();
 });
 
+test('stylelintVSCode() with reportNeedlessDisables', async (t) => {
+	t.plan(1);
+
+	(async () => {
+		t.deepEqual(
+			await stylelintVSCode(
+				new Document(
+					'test.css',
+					'css',
+					`
+.foo {
+  /* stylelint-disable-next-line indentation */
+    color: red;
+}
+
+/* stylelint-disable indentation */
+.bar {
+    color: red;
+}
+/* stylelint-enable indentation */
+
+.baz {
+    color: red; /* stylelint-disable-line indentation */
+}
+
+/* stylelint-disable indentation */
+.bar {
+    color: red;
+}
+`,
+				),
+				{
+					config: { rules: { indentation: [4] } },
+					reportNeedlessDisables: true,
+				},
+			),
+			{
+				diagnostics: [
+					{
+						range: { start: { line: 3, character: 0 }, end: { line: 3, character: 15 } },
+						message: 'unused rule: indentation, start line: 4, end line: 4',
+						severity: WARNING,
+						code: 'indentation',
+						source: 'stylelint',
+					},
+					{
+						range: { start: { line: 6, character: 0 }, end: { line: 10, character: 34 } },
+						message: 'unused rule: indentation, start line: 7, end line: 11',
+						severity: WARNING,
+						code: 'indentation',
+						source: 'stylelint',
+					},
+					{
+						range: { start: { line: 13, character: 0 }, end: { line: 13, character: 56 } },
+						message: 'unused rule: indentation, start line: 14, end line: 14',
+						severity: WARNING,
+						code: 'indentation',
+						source: 'stylelint',
+					},
+					{
+						range: { start: { line: 16, character: 0 }, end: { line: 20, character: 0 } },
+						message: 'unused rule: indentation, start line: 17',
+						severity: WARNING,
+						code: 'indentation',
+						source: 'stylelint',
+					},
+					{
+						range: { start: { line: 2, character: 2 }, end: { line: 2, character: 2 } },
+						message: 'Expected indentation of 4 spaces (indentation)',
+						severity: ERROR,
+						code: 'indentation',
+						source: 'stylelint',
+					},
+				],
+				needlessDisables: [
+					{
+						range: { start: 4, end: 4, unusedRule: 'indentation' },
+						diagnostic: {
+							range: { start: { line: 3, character: 0 }, end: { line: 3, character: 15 } },
+							message: 'unused rule: indentation, start line: 4, end line: 4',
+							severity: WARNING,
+							code: 'indentation',
+							source: 'stylelint',
+						},
+					},
+					{
+						range: { start: 7, end: 11, unusedRule: 'indentation' },
+						diagnostic: {
+							range: { start: { line: 6, character: 0 }, end: { line: 10, character: 34 } },
+							message: 'unused rule: indentation, start line: 7, end line: 11',
+							severity: WARNING,
+							code: 'indentation',
+							source: 'stylelint',
+						},
+					},
+					{
+						range: { start: 14, end: 14, unusedRule: 'indentation' },
+						diagnostic: {
+							range: { start: { line: 13, character: 0 }, end: { line: 13, character: 56 } },
+							message: 'unused rule: indentation, start line: 14, end line: 14',
+							severity: WARNING,
+							code: 'indentation',
+							source: 'stylelint',
+						},
+					},
+					{
+						range: { start: 17, end: undefined, unusedRule: 'indentation' },
+						diagnostic: {
+							range: { start: { line: 16, character: 0 }, end: { line: 20, character: 0 } },
+							message: 'unused rule: indentation, start line: 17',
+							severity: WARNING,
+							code: 'indentation',
+							source: 'stylelint',
+						},
+					},
+				],
+			},
+			'should work properly if reportNeedlessDisables is true.',
+		);
+	})();
+});
+
 test('stylelintVSCode() with stylelintPath', async (t) => {
 	t.plan(2);
 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,11 @@
           "default": "",
           "description": "An absolute path to a custom PostCSS-compatible syntax module."
         },
+        "stylelint.reportNeedlessDisables": {
+          "type": "boolean",
+          "default": false,
+          "description": "Also report errors for `stylelint-disable` comments that are not blocking a lint warning."
+        },
         "stylelint.stylelintPath": {
           "type": "string",
           "default": "",

--- a/test/ws-report-needless-disables-test/.vscode/settings.json
+++ b/test/ws-report-needless-disables-test/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"stylelint.reportNeedlessDisables": true,
+	"editor.codeActionsOnSave": {
+		"source.fixAll.stylelint": false
+	}
+}

--- a/test/ws-report-needless-disables-test/index.js
+++ b/test/ws-report-needless-disables-test/index.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const path = require('path');
+const pWaitFor = require('p-wait-for');
+const test = require('tape');
+const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
+
+const run = () =>
+	test('vscode-stylelint with "stylelint.reportNeedlessDisables"', async (t) => {
+		await commands.executeCommand('vscode.openFolder', Uri.file(__dirname));
+
+		const vscodeStylelint = extensions.getExtension('stylelint.vscode-stylelint');
+
+		// Open the './test.css' file.
+		const cssDocument = await workspace.openTextDocument(path.resolve(__dirname, 'test.css'));
+
+		await window.showTextDocument(cssDocument);
+
+		// Wait for diagnostics result.
+		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
+		await pWaitFor(() => languages.getDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+
+		// Check the result.
+		const diagnostics = languages.getDiagnostics(cssDocument.uri);
+
+		t.deepEqual(
+			diagnostics.map((o) => ({ ...o, range: normalizeRange(o.range) })),
+			[
+				{
+					range: { start: { line: 3, character: 0 }, end: { line: 3, character: 15 } },
+					message: 'unused rule: indentation, start line: 4, end line: 4',
+					severity: 1,
+					code: 'indentation',
+					source: 'stylelint',
+				},
+				{
+					range: { start: { line: 6, character: 0 }, end: { line: 10, character: 34 } },
+					message: 'unused rule: indentation, start line: 7, end line: 11',
+					severity: 1,
+					code: 'indentation',
+					source: 'stylelint',
+				},
+				{
+					range: { start: { line: 14, character: 0 }, end: { line: 14, character: 56 } },
+					message: 'unused rule: indentation, start line: 15, end line: 15',
+					severity: 1,
+					code: 'indentation',
+					source: 'stylelint',
+				},
+				{
+					range: { start: { line: 17, character: 0 }, end: { line: 21, character: 0 } },
+					message: 'unused rule: indentation, start line: 18',
+					severity: 1,
+					code: 'indentation',
+					source: 'stylelint',
+				},
+				{
+					range: { start: { line: 2, character: 2 }, end: { line: 2, character: 2 } },
+					message: 'Expected indentation of 4 spaces (indentation)',
+					severity: 0,
+					code: 'indentation',
+					source: 'stylelint',
+				},
+			],
+			'should work if "stylelint.reportNeedlessDisables" is enabled.',
+		);
+
+		t.end();
+	});
+
+exports.run = (root, done) => {
+	test.onFinish(done);
+	run();
+};
+
+function normalizeRange(range) {
+	const obj = {
+		start: {
+			line: range.start.line,
+			character: range.start.character,
+		},
+	};
+
+	if (range.end !== undefined) {
+		obj.end = {
+			line: range.end.line,
+			character: range.end.character,
+		};
+	}
+
+	return obj;
+}

--- a/test/ws-report-needless-disables-test/stylelint.config.js
+++ b/test/ws-report-needless-disables-test/stylelint.config.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+	rules: {
+		indentation: [4],
+	},
+};

--- a/test/ws-report-needless-disables-test/test.css
+++ b/test/ws-report-needless-disables-test/test.css
@@ -1,0 +1,21 @@
+/* prettier-ignore */
+.foo {
+  /* stylelint-disable-next-line indentation, unknown */
+    color: red;
+}
+
+/* stylelint-disable indentation */ /* prettier-ignore */
+.bar {
+    color: red;
+}
+/* stylelint-enable indentation */
+
+/* prettier-ignore */
+.baz {
+    color: red; /* stylelint-disable-line indentation */
+}
+
+/* stylelint-disable indentation */ /* prettier-ignore */
+.bar {
+    color: red;
+}


### PR DESCRIPTION
<!---
Except for minor documentation fixes, each pull request must be associated with an open issue. If a corresponding issue does not exist, please stop. Instead, create an issue so we can discuss the change first.

If an issue exists, please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Related to #38.

> Is there anything in the PR that needs further explanation?

This PR adds the "stylelint.reportNeedlessDisables" option.
The "stylelint.reportNeedlessDisables" option is passed to the [`reportNeedlessDisables`] option in stylelint's Node.js API.

The result is displayed on the marker.

![image](https://user-images.githubusercontent.com/16508807/74602335-b35ce380-50ea-11ea-8926-ba3a41e4d92e.png)

The output error supports quick fix.

![image](https://user-images.githubusercontent.com/16508807/74602361-ffa82380-50ea-11ea-9b62-becf8d7e8c5f.png)
![image](https://user-images.githubusercontent.com/16508807/74602369-0df63f80-50eb-11ea-9322-5b4d6ecd7500.png)


[`reportNeedlessDisables`]: https://stylelint.io/user-guide/usage/options#reportneedlessdisables