### PR TITLE
Add `snippets` folder to `.vscodeignore`

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,3 +8,4 @@
 !server.js
 !LICENSE.txt
 !lib/**/*
+!snippets/**/*


### PR DESCRIPTION
This PR fixes an isssue where the `/snippets` folder was not included in the  published extension:

`[2020-02-17 19:25:08.320] [renderer1] [error] Error: Unable to read file '/Users/netweb/.vscode/extensions/stylelint.vscode-stylelint-0.82.0/snippets/stylelint-disable.json' (EntryNotFound (FileSystemError): Error: ENOENT: no such file or directory, open '/Users/netweb/.vscode/extensions/stylelint.vscode-stylelint-0.82.0/snippets/stylelint-disable.json')`