### PR TITLE
Add "stylelint.reportInvalidScopeDisables" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ Default: `false`
 
 Set stylelint [`reportNeedlessDisables`](https://stylelint.io/user-guide/usage/options#reportneedlessdisables) option. If `true`, also report errors for `stylelint-disable` comments that are not blocking a lint warning.
 
+#### stylelint.reportInvalidScopeDisables
+
+Type: `boolean`  
+Default: `false`
+
+Set stylelint [`reportInvalidScopeDisables`](https://stylelint.io/user-guide/usage/options#reportInvalidScopeDisables) option. If `true`, also report errors for `stylelint-disable` comments that used for rules that don't exist within the configuration object.
+
 #### stylelint.validate
 
 Type: `string[]`  

--- a/lib/stylelint-vscode/index.js
+++ b/lib/stylelint-vscode/index.js
@@ -19,7 +19,11 @@ const stylelintWarningToVscodeDiagnostic = require('../stylelint-warning-to-vsco
  * @typedef { import('vscode-languageserver').IConnection } IConnection
  * @typedef { "npm" | "yarn" | "pnpm" } PackageManager
  * @typedef { {connection?: IConnection, packageManager?: PackageManager, stylelintPath?: string } } StylelintVSCodeOption
- * @typedef { { diagnostics: Diagnostic[], output?: string, needlessDisables?: ({ diagnostic: Diagnostic, range: DisableReportRange })[] } } StylelintVSCodeResult
+ * @typedef {object} StylelintVSCodeResult
+ * @property {Diagnostic[]} diagnostics
+ * @property {string} [output]
+ * @property {({ diagnostic: Diagnostic, range: DisableReportRange })[]} [needlessDisables]
+ * @property {({ diagnostic: Diagnostic, range: DisableReportRange })[]} [invalidScopeDisables]
  * @typedef { import('stylelint').LinterOptions } BaseStylelintLinterOptions
  * @typedef { Partial<BaseStylelintLinterOptions> } StylelintLinterOptions
  * @typedef { import('stylelint').SyntaxType } SyntaxType
@@ -86,9 +90,16 @@ function processResults(resultContainer, textDocument, ruleDocUrlProvider) {
 	/** @type {StylelintDisableReportEntry[]} */
 	// @ts-expect-error -- The stylelint type is old.
 	const needlessDisables = resultContainer.needlessDisables;
+	/** @type {StylelintDisableReportEntry[]} */
+	// @ts-expect-error -- The stylelint type is old.
+	const invalidScopeDisables = resultContainer.invalidScopeDisables;
 
 	// https://github.com/stylelint/stylelint/blob/12.0.1/lib/standalone.js#L128-L134
-	if (results.length === 0 && (!needlessDisables || needlessDisables.length === 0)) {
+	if (
+		results.length === 0 &&
+		(!needlessDisables || needlessDisables.length === 0) &&
+		(!invalidScopeDisables || invalidScopeDisables.length === 0)
+	) {
 		return {
 			diagnostics: [],
 		};
@@ -108,6 +119,7 @@ function processResults(resultContainer, textDocument, ruleDocUrlProvider) {
 
 	const diagnostics = [];
 	let needlessDisableResults;
+	let invalidScopeDisableResults;
 
 	const needlessDisableSourceReport = needlessDisables && needlessDisables[0];
 
@@ -125,6 +137,22 @@ function processResults(resultContainer, textDocument, ruleDocUrlProvider) {
 		}
 	}
 
+	const invalidScopeDisableSourceReport = invalidScopeDisables && invalidScopeDisables[0];
+
+	if (invalidScopeDisableSourceReport) {
+		invalidScopeDisableResults = [];
+
+		for (const range of invalidScopeDisableSourceReport.ranges) {
+			const diagnostic = stylelintDisableOptionsReportRangeToVscodeDiagnostic(range, textDocument);
+
+			diagnostics.push(diagnostic);
+			invalidScopeDisableResults.push({
+				range,
+				diagnostic,
+			});
+		}
+	}
+
 	diagnostics.push(
 		...warnings.map((warning) => stylelintWarningToVscodeDiagnostic(warning, ruleDocUrlProvider)),
 	);
@@ -134,12 +162,14 @@ function processResults(resultContainer, textDocument, ruleDocUrlProvider) {
 			diagnostics,
 			output: resultContainer.output,
 			...(needlessDisableResults ? { needlessDisables: needlessDisableResults } : {}),
+			...(invalidScopeDisableResults ? { invalidScopeDisables: invalidScopeDisableResults } : {}),
 		};
 	}
 
 	return {
 		diagnostics,
 		...(needlessDisableResults ? { needlessDisables: needlessDisableResults } : {}),
+		...(invalidScopeDisableResults ? { invalidScopeDisables: invalidScopeDisableResults } : {}),
 	};
 }
 

--- a/lib/stylelint-vscode/test/test.js
+++ b/lib/stylelint-vscode/test/test.js
@@ -834,6 +834,98 @@ test('stylelintVSCode() with reportNeedlessDisables', async (t) => {
 	})();
 });
 
+test('stylelintVSCode() with reportInvalidScopeDisables', async (t) => {
+	t.plan(1);
+
+	(async () => {
+		t.deepEqual(
+			await stylelintVSCode(
+				new Document(
+					'test.css',
+					'css',
+					`
+/* stylelint-disable-next-line foo */
+
+/* stylelint-disable-line foo */
+
+/* stylelint-disable foo */
+/* stylelint-enable foo */
+
+/* stylelint-disable-next-line indentation */
+
+/* stylelint-disable-line indentation */
+
+/* stylelint-disable indentation */
+/* stylelint-enable indentation */
+`,
+				),
+				{
+					config: { rules: { indentation: [4] } },
+					reportInvalidScopeDisables: true,
+				},
+			),
+			{
+				diagnostics: [
+					{
+						range: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } },
+						message: 'unused rule: foo, start line: 3, end line: 3',
+						severity: 2,
+						code: 'foo',
+						source: 'stylelint',
+					},
+					{
+						range: { start: { line: 3, character: 0 }, end: { line: 3, character: 32 } },
+						message: 'unused rule: foo, start line: 4, end line: 4',
+						severity: 2,
+						code: 'foo',
+						source: 'stylelint',
+					},
+					{
+						range: { start: { line: 5, character: 0 }, end: { line: 6, character: 26 } },
+						message: 'unused rule: foo, start line: 6, end line: 7',
+						severity: 2,
+						code: 'foo',
+						source: 'stylelint',
+					},
+				],
+				invalidScopeDisables: [
+					{
+						range: { unusedRule: 'foo', start: 3, end: 3 },
+						diagnostic: {
+							range: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } },
+							message: 'unused rule: foo, start line: 3, end line: 3',
+							severity: 2,
+							code: 'foo',
+							source: 'stylelint',
+						},
+					},
+					{
+						range: { unusedRule: 'foo', start: 4, end: 4 },
+						diagnostic: {
+							range: { start: { line: 3, character: 0 }, end: { line: 3, character: 32 } },
+							message: 'unused rule: foo, start line: 4, end line: 4',
+							severity: 2,
+							code: 'foo',
+							source: 'stylelint',
+						},
+					},
+					{
+						range: { unusedRule: 'foo', start: 6, end: 7 },
+						diagnostic: {
+							range: { start: { line: 5, character: 0 }, end: { line: 6, character: 26 } },
+							message: 'unused rule: foo, start line: 6, end line: 7',
+							severity: 2,
+							code: 'foo',
+							source: 'stylelint',
+						},
+					},
+				],
+			},
+			'should work properly if reportInvalidScopeDisables is true.',
+		);
+	})();
+});
+
 test('stylelintVSCode() with stylelintPath', async (t) => {
 	t.plan(2);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,14 +172,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
       "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
     },
-    "@babel/runtime": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@babel/template": {
       "version": "7.8.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
@@ -562,9 +554,9 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
     },
     "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
     },
     "assert-valid-glob-opts": {
       "version": "1.0.0",
@@ -582,17 +574,17 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "autoprefixer": {
-      "version": "9.7.6",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.6.tgz",
-      "integrity": "sha512-F7cYpbN7uVVhACZTeeIeealwdGM6wMtfWARVLTy5xmKtgVdBNJvbDRoCK3YO1orcs7gv/KwYlb3iXwu9Ug9BkQ==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.0.tgz",
+      "integrity": "sha512-D96ZiIHXbDmU02dBaemyAg53ez+6F5yZmapmgKcjm35yEe1uVDYI8hGW3VYoGRaG290ZFf91YxHrR518vC0u/A==",
       "requires": {
-        "browserslist": "^4.11.1",
-        "caniuse-lite": "^1.0.30001039",
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001061",
         "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.27",
-        "postcss-value-parser": "^4.0.3"
+        "postcss": "^7.0.30",
+        "postcss-value-parser": "^4.1.0"
       },
       "dependencies": {
         "chalk": {
@@ -604,6 +596,31 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
+        },
+        "postcss": {
+          "version": "7.0.32",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
+          "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -641,12 +658,12 @@
       }
     },
     "browserslist": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
-      "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
+      "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
       "requires": {
-        "caniuse-lite": "^1.0.30001038",
-        "electron-to-chromium": "^1.3.390",
+        "caniuse-lite": "^1.0.30001043",
+        "electron-to-chromium": "^1.3.413",
         "node-releases": "^1.1.53",
         "pkg-up": "^2.0.0"
       }
@@ -690,9 +707,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001040",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001040.tgz",
-      "integrity": "sha512-Ep0tEPeI5wCvmJNrXjE3etgfI+lkl1fTDU6Y3ZH1mhrjkPlVI9W4pcKbMo+BQLpEWKVYYp2EmYaRsqpPC3k7lQ=="
+      "version": "1.0.30001077",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001077.tgz",
+      "integrity": "sha512-AEzsGvjBJL0lby/87W96PyEvwN0GsYvk5LHsglLg9tW37K4BqvAvoSCdWIE13OZQ8afupqZ73+oL/1LkedN8hA=="
     },
     "ccount": {
       "version": "1.0.5",
@@ -983,9 +1000,9 @@
           "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
         },
         "entities": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
         }
       }
     },
@@ -1021,9 +1038,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.403",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.403.tgz",
-      "integrity": "sha512-JaoxV4RzdBAZOnsF4dAlZ2ijJW72MbqO5lNfOBHUWiBQl3Rwe+mk2RCUMrRI3rSClLJ8HSNQNqcry12H+0ZjFw=="
+      "version": "1.3.461",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.461.tgz",
+      "integrity": "sha512-+mqXoHkp30WofnhiHNuy5KXBeOx6Jtqpgz42F/NHSTk0/GA1g5plDY0Cwy0A31NVs5V3rfskK18gKy6x2rElUw=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -1427,9 +1444,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.7.0.tgz",
-      "integrity": "sha512-YOadQRnHd5q6PogvAR/x62BGituF2ufiEA6s8aavQANw5YKHERI4AREboX6KotzP8oX2klxYF2wcV/7bn1clfQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -1614,9 +1631,9 @@
       "dev": true
     },
     "get-stdin": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
-      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg=="
     },
     "glob": {
       "version": "7.1.6",
@@ -1669,9 +1686,9 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
-      "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+      "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -2339,9 +2356,9 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "known-css-properties": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.18.0.tgz",
-      "integrity": "sha512-69AgJ1rQa7VvUsd2kpvVq+VeObDuo3zrj0CzM5Slmf6yduQFAI2kXPDQJR2IE/u6MSAUOJrwSzjg5vlz8qcMiw=="
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.19.0.tgz",
+      "integrity": "sha512-eYboRV94Vco725nKMlpkn3nV2+96p9c3gKXRsYqAJSswSENvBhN7n5L+uDhY58xQa0UukWsDMTGELzmD8Q+wTA=="
     },
     "leven": {
       "version": "3.1.0",
@@ -2420,23 +2437,11 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
       "requires": {
-        "chalk": "^2.4.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
+        "chalk": "^4.0.0"
       }
     },
     "longest-streak": {
@@ -2499,27 +2504,57 @@
       "dev": true
     },
     "meow": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-6.1.0.tgz",
-      "integrity": "sha512-iIAoeI01v6pmSfObAAWFoITAA4GgiT45m4SmJgoxtZfvI0fyZwhV4d0lTwiUXvAKIPlma05Feb2Xngl52Mj5Cg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
+      "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
       "requires": {
         "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.1.1",
+        "arrify": "^2.0.1",
+        "camelcase": "^6.0.0",
+        "camelcase-keys": "^6.2.2",
         "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.0.0",
-        "minimist-options": "^4.0.1",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "^4.0.2",
         "normalize-package-data": "^2.5.0",
-        "read-pkg-up": "^7.0.0",
+        "read-pkg-up": "^7.0.1",
         "redent": "^3.0.0",
         "trim-newlines": "^3.0.0",
-        "type-fest": "^0.8.1",
-        "yargs-parser": "^18.1.1"
+        "type-fest": "^0.13.1",
+        "yargs-parser": "^18.1.3"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
+        },
+        "type-fest": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+            }
+          }
+        }
       }
     },
     "merge2": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "micromatch": {
       "version": "4.0.2",
@@ -2537,9 +2572,9 @@
       "dev": true
     },
     "min-indent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
-      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2555,14 +2590,20 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.0.2.tgz",
-      "integrity": "sha512-seq4hpWkYSUh1y7NXxzucwAN9yVlBc3Upgdjz8vLCP97jG8kaOmzYrVH/m7tQ1NYD1wdtZbSLfdy4zFmRWuc/w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
       "requires": {
         "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
       },
       "dependencies": {
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+        },
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -2617,9 +2658,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.53",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
-      "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
+      "version": "1.1.58",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.58.tgz",
+      "integrity": "sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -3238,11 +3279,11 @@
       }
     },
     "postcss-scss": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.0.0.tgz",
-      "integrity": "sha512-um9zdGKaDZirMm+kZFKKVsnKPF7zF7qBAtIfTSnZXD1jZ0JNZIxdB6TxQOjCnlSzLRInVl2v3YdBh/M881C4ug==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.1.1.tgz",
+      "integrity": "sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==",
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "^7.0.6"
       }
     },
     "postcss-selector-parser": {
@@ -3261,9 +3302,9 @@
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w=="
     },
     "postcss-value-parser": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
-      "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -3394,11 +3435,6 @@
         "strip-indent": "^3.0.0"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
-    },
     "regexp.prototype.flags": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
@@ -3435,9 +3471,9 @@
       }
     },
     "remark-parse": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.0.tgz",
-      "integrity": "sha512-Ck14G1Ns/GEPXhSw6m1Uv28kMtVk63e59NyL+QlhBBwBdIUXROM6MPfBehPhW6TW2d73batMdZsKwuxl5i3tEA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.2.tgz",
+      "integrity": "sha512-eMI6kMRjsAGpMXXBAywJwiwAse+KNpmt+BK55Oofy4KvBZEqUDj6mWbGLJZrujoPIPPxDXzn3T9baRlpsm2jnQ==",
       "requires": {
         "ccount": "^1.0.0",
         "collapse-white-space": "^1.0.2",
@@ -3861,16 +3897,16 @@
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
     "stringify-entities": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.0.0.tgz",
-      "integrity": "sha512-h7NJJIssprqlyjHT2eQt2W1F+MCcNmwPGlKb0bWEdET/3N44QN3QbUF/ueKCgAssyKRZ3Br9rQ7FcXjHr0qLHw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.0.1.tgz",
+      "integrity": "sha512-Lsk3ISA2++eJYqBMPKcr/8eby1I6L0gP0NlxF8Zja6c05yr/yCYyb2c9PwXjd08Ib3If1vn1rbs1H5ZtVuOfvQ==",
       "requires": {
         "character-entities-html4": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -3913,36 +3949,36 @@
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
     },
     "stylelint": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.3.2.tgz",
-      "integrity": "sha512-kpO3/Gz2ZY40EWUwFYYkgpzhf8ZDUyKpcui5+pS0XKJBj/EMYmZpOJoL8IFAz2yApYeg91NVy5yAjE39hDzWvQ==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.6.0.tgz",
+      "integrity": "sha512-55gG2pNjVr183JJM/tlr3KAua6vTVX7Ho/lgKKuCIWszTZ1gmrXjX4Wok53SI8wRYFPbwKAcJGULQ77OJxTcNw==",
       "requires": {
         "@stylelint/postcss-css-in-js": "^0.37.1",
         "@stylelint/postcss-markdown": "^0.36.1",
-        "autoprefixer": "^9.7.6",
+        "autoprefixer": "^9.8.0",
         "balanced-match": "^1.0.0",
         "chalk": "^4.0.0",
         "cosmiconfig": "^6.0.0",
         "debug": "^4.1.1",
         "execall": "^2.0.0",
         "file-entry-cache": "^5.0.1",
-        "get-stdin": "^7.0.0",
+        "get-stdin": "^8.0.0",
         "global-modules": "^2.0.0",
-        "globby": "^11.0.0",
+        "globby": "^11.0.1",
         "globjoin": "^0.1.4",
         "html-tags": "^3.1.0",
-        "ignore": "^5.1.4",
+        "ignore": "^5.1.8",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
-        "known-css-properties": "^0.18.0",
+        "known-css-properties": "^0.19.0",
         "leven": "^3.1.0",
         "lodash": "^4.17.15",
-        "log-symbols": "^3.0.0",
+        "log-symbols": "^4.0.0",
         "mathml-tag-names": "^2.1.3",
-        "meow": "^6.1.0",
+        "meow": "^7.0.1",
         "micromatch": "^4.0.2",
         "normalize-selector": "^0.2.0",
-        "postcss": "^7.0.27",
+        "postcss": "^7.0.32",
         "postcss-html": "^0.36.0",
         "postcss-less": "^3.1.4",
         "postcss-media-query-parser": "^0.2.3",
@@ -3950,10 +3986,10 @@
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^4.0.2",
         "postcss-sass": "^0.4.4",
-        "postcss-scss": "^2.0.0",
+        "postcss-scss": "^2.1.1",
         "postcss-selector-parser": "^6.0.2",
         "postcss-syntax": "^0.36.2",
-        "postcss-value-parser": "^4.0.3",
+        "postcss-value-parser": "^4.1.0",
         "resolve-from": "^5.0.0",
         "slash": "^3.0.0",
         "specificity": "^0.4.1",
@@ -3963,8 +3999,65 @@
         "sugarss": "^2.0.0",
         "svg-tags": "^1.0.0",
         "table": "^5.4.6",
-        "v8-compile-cache": "^2.1.0",
+        "v8-compile-cache": "^2.1.1",
         "write-file-atomic": "^3.0.3"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+        },
+        "postcss": {
+          "version": "7.0.32",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
+          "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "v8-compile-cache": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+          "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
+        }
       }
     },
     "stylelint-processor-glamorous": {
@@ -4317,7 +4410,8 @@
     "v8-compile-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g=="
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
     },
     "validate-glob-opts": {
       "version": "1.0.2",
@@ -4349,9 +4443,9 @@
       }
     },
     "vfile": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.0.tgz",
-      "integrity": "sha512-BaTPalregj++64xbGK6uIlsurN3BCRNM/P2Pg8HezlGzKd1O9PrwIac6bd9Pdx2uTb0QHoioZ+rXKolbVXEgJg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.1.tgz",
+      "integrity": "sha512-lRjkpyDGjVlBA7cDQhQ+gNcvB1BGaTHYuSOcY3S7OhDmBtnzX95FhtZZDecSTDm6aajFymyve6S5DN4ZHGezdQ==",
       "requires": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -4532,12 +4626,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.3.tgz",
-      "integrity": "sha512-X/v7VDnK+sxbQ2Imq4Jt2PRUsRsP7UcpSl3Llg6+NRRqWLIvxkMFYtH1FmvwNGYRKKPa+EPA4qDBlI9WVG1UKw==",
-      "requires": {
-        "@babel/runtime": "^7.8.7"
-      }
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yargs": {
       "version": "15.3.1",
@@ -4613,6 +4704,7 @@
       "version": "18.1.2",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
       "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
+      "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
           "default": false,
           "description": "Also report errors for `stylelint-disable` comments that are not blocking a lint warning."
         },
+        "stylelint.reportInvalidScopeDisables": {
+          "type": "boolean",
+          "default": false,
+          "description": "Also report errors for `stylelint-disable` comments that used for rules that don't exist within the configuration object."
+        },
         "stylelint.stylelintPath": {
           "type": "string",
           "default": "",
@@ -169,7 +174,7 @@
     "kind-of": "^6.0.3",
     "lodash": "^4.17.15",
     "path-is-inside": "^1.0.2",
-    "stylelint": "^13.3.0",
+    "stylelint": "^13.6.0",
     "vscode-languageclient": "^6.2.0-next.1",
     "vscode-languageserver": "^6.2.0-next.1",
     "vscode-languageserver-textdocument": "^1.0.1",

--- a/test/ws-report-invalid-scope-disables-test/.vscode/settings.json
+++ b/test/ws-report-invalid-scope-disables-test/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"stylelint.reportInvalidScopeDisables": true,
+	"editor.codeActionsOnSave": {
+		"source.fixAll.stylelint": false
+	}
+}

--- a/test/ws-report-invalid-scope-disables-test/index.js
+++ b/test/ws-report-invalid-scope-disables-test/index.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const path = require('path');
+const pWaitFor = require('p-wait-for');
+const test = require('tape');
+const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
+const { normalizeDiagnostic } = require('../utils');
+
+const run = () =>
+	test('vscode-stylelint with "stylelint.reportInvalidScopeDisables"', async (t) => {
+		await commands.executeCommand('vscode.openFolder', Uri.file(__dirname));
+
+		const vscodeStylelint = extensions.getExtension('stylelint.vscode-stylelint');
+
+		// Open the './test.css' file.
+		const cssDocument = await workspace.openTextDocument(path.resolve(__dirname, 'test.css'));
+
+		await window.showTextDocument(cssDocument);
+
+		// Wait for diagnostics result.
+		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
+		await pWaitFor(() => languages.getDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+
+		// Check the result.
+		const diagnostics = languages.getDiagnostics(cssDocument.uri);
+
+		t.deepEqual(
+			diagnostics.map(normalizeDiagnostic),
+			[
+				{
+					range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } },
+					message: 'unused rule: foo, start line: 2, end line: 2',
+					severity: 1,
+					code: 'foo',
+					source: 'stylelint',
+				},
+				{
+					range: { start: { line: 2, character: 0 }, end: { line: 2, character: 32 } },
+					message: 'unused rule: foo, start line: 3, end line: 3',
+					severity: 1,
+					code: 'foo',
+					source: 'stylelint',
+				},
+				{
+					range: { start: { line: 4, character: 0 }, end: { line: 5, character: 26 } },
+					message: 'unused rule: foo, start line: 5, end line: 6',
+					severity: 1,
+					code: 'foo',
+					source: 'stylelint',
+				},
+			],
+			'should work if "stylelint.reportInvalidScopeDisables" is enabled.',
+		);
+
+		t.end();
+	});
+
+exports.run = (root, done) => {
+	test.onFinish(done);
+	run();
+};

--- a/test/ws-report-invalid-scope-disables-test/stylelint.config.js
+++ b/test/ws-report-invalid-scope-disables-test/stylelint.config.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+	rules: {
+		indentation: [4],
+	},
+};

--- a/test/ws-report-invalid-scope-disables-test/test.css
+++ b/test/ws-report-invalid-scope-disables-test/test.css
@@ -1,0 +1,13 @@
+/* stylelint-disable-next-line foo */
+
+/* stylelint-disable-line foo */
+
+/* stylelint-disable foo */
+/* stylelint-enable foo */
+
+/* stylelint-disable-next-line indentation */
+
+/* stylelint-disable-line indentation */
+
+/* stylelint-disable indentation */
+/* stylelint-enable indentation */


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #38.

> Is there anything in the PR that needs further explanation?


This PR adds the "stylelint.reportInvalidScopeDisables" option.
The "stylelint.reportInvalidScopeDisables" option is passed to the [`reportInvalidScopeDisables`] option in stylelint's Node.js API.

The result is displayed on the marker.

![image](https://user-images.githubusercontent.com/16508807/83845294-8721ad00-a743-11ea-9db2-3ba12c1a9bee.png)

The output error supports quick fix.

![image](https://user-images.githubusercontent.com/16508807/83845351-a587a880-a743-11ea-9014-d5b48673bd60.png)



[`reportInvalidScopeDisables`]: https://stylelint.io/user-guide/usage/options#reportneedlessdisables
