### PR TITLE
Add "stylelint.configBasedir" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ Default: `null`
 
 Set stylelint [`config`](https://stylelint.io/user-guide/usage/node-api#config) option. Note that when this option is enabled, stylelint doesn't load configuration files.
 
+#### stylelint.configBasedir
+
+Type: `string`  
+Default: `""`
+
+Set stylelint [`configBasedir`](https://stylelint.io/user-guide/usage/options#configbasedir) option. The path to the directory that relative paths defining "extends" and "plugins" are relative to. Only necessary if these values are relative paths.
+
 #### stylelint.customSyntax
 
 Type: `string`  

--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
           "default": null,
           "description": "A partial stylelint config whose properties override the existing ones."
         },
+        "stylelint.configBasedir": {
+          "type": "string",
+          "default": "",
+          "description": "A path to the directory that relative paths defining \"extends\" and \"plugins\" are relative to."
+        },
         "stylelint.customSyntax": {
           "type": "string",
           "default": "",

--- a/server.js
+++ b/server.js
@@ -51,6 +51,8 @@ const StylelintSourceFixAll = `${CodeActionKind.SourceFixAll}.stylelint`;
 let config;
 /** @type {StylelintConfiguration} */
 let configOverrides;
+/** @type {string} */
+let configBasedir;
 /** @type {PackageManager} */
 let packageManager;
 /** @type {string} */
@@ -115,6 +117,14 @@ async function buildStylelintOptions(document, baseOptions = {}) {
 		options.customSyntax = workspaceFolder
 			? customSyntax.replace(/\$\{workspaceFolder\}/gu, workspaceFolder)
 			: customSyntax;
+	}
+
+	if (configBasedir) {
+		if (isAbsolute(configBasedir)) {
+			options.configBasedir = configBasedir;
+		} else {
+			options.configBasedir = join(workspaceFolder || '', configBasedir);
+		}
 	}
 
 	if (documentPath) {
@@ -300,6 +310,7 @@ connection.onDidChangeConfiguration(({ settings }) => {
 
 	config = settings.stylelint.config;
 	configOverrides = settings.stylelint.configOverrides;
+	configBasedir = settings.stylelint.configBasedir;
 	customSyntax = settings.stylelint.customSyntax;
 	reportNeedlessDisables = settings.stylelint.reportNeedlessDisables;
 	reportInvalidScopeDisables = settings.stylelint.reportInvalidScopeDisables;

--- a/test/ws-config-basedir-test/.vscode/settings.json
+++ b/test/ws-config-basedir-test/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"stylelint.configBasedir": "config-basedir"
+}

--- a/test/ws-config-basedir-test/config-basedir/stylelint-config1.js
+++ b/test/ws-config-basedir-test/config-basedir/stylelint-config1.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+	rules: {
+		indentation: [8],
+	},
+};

--- a/test/ws-config-basedir-test/config-basedir/stylelint-config2.js
+++ b/test/ws-config-basedir-test/config-basedir/stylelint-config2.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+	rules: {
+		'color-hex-case': ['upper'],
+	},
+};

--- a/test/ws-config-basedir-test/index.js
+++ b/test/ws-config-basedir-test/index.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const path = require('path');
+const pWaitFor = require('p-wait-for');
+const test = require('tape');
+const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
+const { normalizeDiagnostic } = require('../utils');
+
+const run = () =>
+	test('vscode-stylelint with "stylelint.configBasedir"', async (t) => {
+		await commands.executeCommand('vscode.openFolder', Uri.file(__dirname));
+
+		const vscodeStylelint = extensions.getExtension('stylelint.vscode-stylelint');
+
+		// Open the './test.css' file.
+		const cssDocument = await workspace.openTextDocument(path.resolve(__dirname, 'test.css'));
+
+		await window.showTextDocument(cssDocument);
+
+		// Wait for diagnostics result.
+		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
+		await pWaitFor(() => languages.getDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+
+		// Check the result.
+		const diagnostics = languages.getDiagnostics(cssDocument.uri);
+
+		t.deepEqual(
+			diagnostics.map(normalizeDiagnostic),
+			[
+				{
+					range: { start: { line: 2, character: 9 }, end: { line: 2, character: 9 } },
+					message: 'Expected "#fff" to be "#FFF" (color-hex-case)',
+					severity: 0,
+					code: {
+						value: 'color-hex-case',
+						target: {
+							scheme: 'https',
+							authority: 'stylelint.io',
+							path: '/user-guide/rules/color-hex-case',
+						},
+					},
+					source: 'stylelint',
+				},
+				{
+					range: { start: { line: 2, character: 2 }, end: { line: 2, character: 2 } },
+					message: 'Expected indentation of 8 spaces (indentation)',
+					severity: 0,
+					code: {
+						value: 'indentation',
+						target: {
+							scheme: 'https',
+							authority: 'stylelint.io',
+							path: '/user-guide/rules/indentation',
+						},
+					},
+					source: 'stylelint',
+				},
+			],
+			'should work even if "stylelint.configBasedir" is defined.',
+		);
+
+		t.end();
+	});
+
+exports.run = (root, done) => {
+	test.onFinish(done);
+	run();
+};

--- a/test/ws-config-basedir-test/stylelint.config.js
+++ b/test/ws-config-basedir-test/stylelint.config.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+	extends: ['./stylelint-config1', './stylelint-config2'],
+};

--- a/test/ws-config-basedir-test/test.css
+++ b/test/ws-config-basedir-test/test.css
@@ -1,0 +1,4 @@
+/* prettier-ignore */
+a {
+  color: #fff;
+}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #38.

> Is there anything in the PR that needs further explanation?

This PR adds the `"stylelint.configBasedir"` option.
The `"stylelint.configBasedir"` option is passed to the `configBasedir` option in stylelint's Node.js API.
