### PR TITLE
Add "stylelint.ignoreDisables" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ e.g.
   "stylelint.customSyntax": "${workspaceFolder}/custom-syntax.js"
 ```
 
+#### stylelint.ignoreDisables
+
+Type: `boolean`  
+Default: `false`
+
+Set stylelint [`ignoreDisables`](https://stylelint.io/user-guide/usage/options#ignoredisables) option. If `true`, ignore `styleline-disable` (e.g. `/* stylelint-disable block-no-empty */`) comments.
+
 #### stylelint.reportNeedlessDisables
 
 Type: `boolean`  

--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
           "default": "",
           "description": "An absolute path to a custom PostCSS-compatible syntax module."
         },
+        "stylelint.ignoreDisables": {
+          "type": "boolean",
+          "default": false,
+          "description": "Ignore `styleline-disable` (e.g. `/* stylelint-disable block-no-empty */`) comments"
+        },
         "stylelint.reportNeedlessDisables": {
           "type": "boolean",
           "default": false,

--- a/server.js
+++ b/server.js
@@ -56,6 +56,8 @@ let packageManager;
 /** @type {string} */
 let customSyntax;
 /** @type {boolean} */
+let ignoreDisables;
+/** @type {boolean} */
 let reportNeedlessDisables;
 /** @type {boolean} */
 let reportInvalidScopeDisables;
@@ -97,6 +99,10 @@ async function buildStylelintOptions(document, baseOptions = {}) {
 
 	if (configOverrides) {
 		options.configOverrides = configOverrides;
+	}
+
+	if (ignoreDisables) {
+		options.ignoreDisables = ignoreDisables;
 	}
 
 	if (reportNeedlessDisables) {
@@ -301,6 +307,7 @@ connection.onDidChangeConfiguration(({ settings }) => {
 	config = settings.stylelint.config;
 	configOverrides = settings.stylelint.configOverrides;
 	customSyntax = settings.stylelint.customSyntax;
+	ignoreDisables = settings.stylelint.ignoreDisables;
 	reportNeedlessDisables = settings.stylelint.reportNeedlessDisables;
 	reportInvalidScopeDisables = settings.stylelint.reportInvalidScopeDisables;
 	stylelintPath = settings.stylelint.stylelintPath;

--- a/test/ws-ignore-disables-test/.vscode/settings.json
+++ b/test/ws-ignore-disables-test/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"stylelint.ignoreDisables": true
+}

--- a/test/ws-ignore-disables-test/index.js
+++ b/test/ws-ignore-disables-test/index.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const path = require('path');
+const pWaitFor = require('p-wait-for');
+const test = require('tape');
+const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
+const { normalizeDiagnostic } = require('../utils');
+
+const run = () =>
+	test('vscode-stylelint with "stylelint.ignoreDisables"', async (t) => {
+		await commands.executeCommand('vscode.openFolder', Uri.file(__dirname));
+
+		const vscodeStylelint = extensions.getExtension('stylelint.vscode-stylelint');
+
+		// Open the './test.css' file.
+		const cssDocument = await workspace.openTextDocument(path.resolve(__dirname, 'test.css'));
+
+		await window.showTextDocument(cssDocument);
+
+		// Wait for diagnostics result.
+		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
+		await pWaitFor(() => languages.getDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+
+		// Check the result.
+		const diagnostics = languages.getDiagnostics(cssDocument.uri);
+
+		t.deepEqual(
+			diagnostics.map(normalizeDiagnostic),
+			[
+				{
+					range: { start: { line: 3, character: 9 }, end: { line: 3, character: 9 } },
+					message: 'Expected "#fff" to be "#FFF" (color-hex-case)',
+					severity: 0,
+					code: {
+						value: 'color-hex-case',
+						target: {
+							scheme: 'https',
+							authority: 'stylelint.io',
+							path: '/user-guide/rules/color-hex-case',
+						},
+					},
+					source: 'stylelint',
+				},
+				{
+					range: { start: { line: 3, character: 2 }, end: { line: 3, character: 2 } },
+					message: 'Expected indentation of 4 spaces (indentation)',
+					severity: 0,
+					code: {
+						value: 'indentation',
+						target: {
+							scheme: 'https',
+							authority: 'stylelint.io',
+							path: '/user-guide/rules/indentation',
+						},
+					},
+					source: 'stylelint',
+				},
+			],
+			'should work if "stylelint.ignoreDisables" is enabled.',
+		);
+
+		t.end();
+	});
+
+exports.run = (root, done) => {
+	test.onFinish(done);
+	run();
+};

--- a/test/ws-ignore-disables-test/stylelint.config.js
+++ b/test/ws-ignore-disables-test/stylelint.config.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+	rules: {
+		indentation: [4],
+		'color-hex-case': ['upper'],
+	},
+};

--- a/test/ws-ignore-disables-test/test.css
+++ b/test/ws-ignore-disables-test/test.css
@@ -1,0 +1,5 @@
+/* prettier-ignore */
+a {
+    /* stylelint-disable-next-line indentation */
+  color: #fff;
+}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #38.

> Is there anything in the PR that needs further explanation?

This PR adds the `"stylelint.ignoreDisables"` option.
The `"stylelint.ignoreDisables"` option is passed to the `ignoreDisables` option in stylelint's Node.js API.
