### PR TITLE
Add "stylelint.syntax" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ Default: `""`
 
 Set stylelint [`configBasedir`](https://stylelint.io/user-guide/usage/options#configbasedir) option. The path to the directory that relative paths defining "extends" and "plugins" are relative to. Only necessary if these values are relative paths.
 
+#### stylelint.syntax
+
+Type: `"css" | "css-in-js" | "html" | "less" | "markdown" | "sass" | "scss" | "sugarss"`  
+Default: `""`
+
+Set stylelint [`syntax`](https://stylelint.io/user-guide/usage/options#syntax) option. Specify a syntax. Only use this option if you want to force a specific syntax.
+
 #### stylelint.customSyntax
 
 Type: `string`  

--- a/package.json
+++ b/package.json
@@ -70,6 +70,22 @@
           "default": "",
           "description": "A path to the directory that relative paths defining \"extends\" and \"plugins\" are relative to."
         },
+        "stylelint.syntax": {
+          "type": "string",
+          "default": "",
+          "enum": [
+            "css",
+            "css-in-js",
+            "html",
+            "less",
+            "markdown",
+            "sass",
+            "scss",
+            "sugarss",
+            ""
+          ],
+          "description": "Specify a syntax. Only use this option if you want to force a specific syntax."
+        },
         "stylelint.customSyntax": {
           "type": "string",
           "default": "",

--- a/server.js
+++ b/server.js
@@ -55,6 +55,8 @@ let configOverrides;
 let configBasedir;
 /** @type {PackageManager} */
 let packageManager;
+/** @type { "css-in-js" | "html" | "less" | "markdown" | "sass" | "scss" | "sugarss" | undefined } */
+let syntax;
 /** @type {string} */
 let customSyntax;
 /** @type {boolean} */
@@ -114,6 +116,10 @@ async function buildStylelintOptions(document, baseOptions = {}) {
 	if (reportInvalidScopeDisables) {
 		// @ts-expect-error -- The stylelint type is old.
 		options.reportInvalidScopeDisables = reportInvalidScopeDisables;
+	}
+
+	if (syntax) {
+		options.syntax = syntax;
 	}
 
 	const workspaceFolder = await getWorkspaceFolder(document);
@@ -317,6 +323,7 @@ connection.onDidChangeConfiguration(({ settings }) => {
 	config = settings.stylelint.config;
 	configOverrides = settings.stylelint.configOverrides;
 	configBasedir = settings.stylelint.configBasedir;
+	syntax = settings.stylelint.syntax || undefined;
 	customSyntax = settings.stylelint.customSyntax;
 	ignoreDisables = settings.stylelint.ignoreDisables;
 	reportNeedlessDisables = settings.stylelint.reportNeedlessDisables;

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,11 +1,18 @@
 'use strict';
 
+const { languages } = require('vscode');
+
 module.exports = {
 	normalizeDiagnostic,
+	getStylelintDiagnostics,
 };
 
 function normalizeDiagnostic(message) {
 	return { ...message, code: normalizeCode(message.code), range: normalizeRange(message.range) };
+}
+
+function getStylelintDiagnostics(uri) {
+	return languages.getDiagnostics(uri).filter((d) => d.source === 'stylelint');
 }
 
 function normalizeRange(range) {

--- a/test/ws-config-basedir-test/index.js
+++ b/test/ws-config-basedir-test/index.js
@@ -3,8 +3,8 @@
 const path = require('path');
 const pWaitFor = require('p-wait-for');
 const test = require('tape');
-const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
-const { normalizeDiagnostic } = require('../utils');
+const { extensions, workspace, window, Uri, commands } = require('vscode');
+const { normalizeDiagnostic, getStylelintDiagnostics } = require('../utils');
 
 const run = () =>
 	test('vscode-stylelint with "stylelint.configBasedir"', async (t) => {
@@ -19,10 +19,10 @@ const run = () =>
 
 		// Wait for diagnostics result.
 		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
-		await pWaitFor(() => languages.getDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+		await pWaitFor(() => getStylelintDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
 
 		// Check the result.
-		const diagnostics = languages.getDiagnostics(cssDocument.uri);
+		const diagnostics = getStylelintDiagnostics(cssDocument.uri);
 
 		t.deepEqual(
 			diagnostics.map(normalizeDiagnostic),

--- a/test/ws-ignore-disables-test/index.js
+++ b/test/ws-ignore-disables-test/index.js
@@ -3,8 +3,8 @@
 const path = require('path');
 const pWaitFor = require('p-wait-for');
 const test = require('tape');
-const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
-const { normalizeDiagnostic } = require('../utils');
+const { extensions, workspace, window, Uri, commands } = require('vscode');
+const { normalizeDiagnostic, getStylelintDiagnostics } = require('../utils');
 
 const run = () =>
 	test('vscode-stylelint with "stylelint.ignoreDisables"', async (t) => {
@@ -19,10 +19,10 @@ const run = () =>
 
 		// Wait for diagnostics result.
 		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
-		await pWaitFor(() => languages.getDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+		await pWaitFor(() => getStylelintDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
 
 		// Check the result.
-		const diagnostics = languages.getDiagnostics(cssDocument.uri);
+		const diagnostics = getStylelintDiagnostics(cssDocument.uri);
 
 		t.deepEqual(
 			diagnostics.map(normalizeDiagnostic),

--- a/test/ws-lint-test/index.js
+++ b/test/ws-lint-test/index.js
@@ -3,8 +3,8 @@
 const path = require('path');
 const pWaitFor = require('p-wait-for');
 const test = require('tape');
-const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
-const { normalizeDiagnostic } = require('../utils');
+const { extensions, workspace, window, Uri, commands } = require('vscode');
+const { normalizeDiagnostic, getStylelintDiagnostics } = require('../utils');
 
 const run = () =>
 	test('vscode-stylelint lint test', async (t) => {
@@ -19,11 +19,11 @@ const run = () =>
 
 		// Wait for diagnostics result.
 		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
-		await pWaitFor(() => languages.getDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+		await pWaitFor(() => getStylelintDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
 
 		// Check the result.
 		t.deepEqual(
-			languages.getDiagnostics(cssDocument.uri).map(normalizeDiagnostic),
+			getStylelintDiagnostics(cssDocument.uri).map(normalizeDiagnostic),
 			[
 				{
 					range: { start: { line: 2, character: 2 }, end: { line: 2, character: 2 } },
@@ -49,11 +49,11 @@ const run = () =>
 		await window.showTextDocument(scssDocument);
 
 		// Wait for diagnostics result.
-		await pWaitFor(() => languages.getDiagnostics(scssDocument.uri).length > 0, { timeout: 5000 });
+		await pWaitFor(() => getStylelintDiagnostics(scssDocument.uri).length > 0, { timeout: 5000 });
 
 		// Check the result.
 		t.deepEqual(
-			languages.getDiagnostics(scssDocument.uri).map(normalizeDiagnostic),
+			getStylelintDiagnostics(scssDocument.uri).map(normalizeDiagnostic),
 			[
 				{
 					range: { start: { line: 2, character: 2 }, end: { line: 2, character: 2 } },
@@ -79,11 +79,11 @@ const run = () =>
 		await window.showTextDocument(mdDocument);
 
 		// Wait for diagnostics result.
-		await pWaitFor(() => languages.getDiagnostics(mdDocument.uri).length > 0, { timeout: 5000 });
+		await pWaitFor(() => getStylelintDiagnostics(mdDocument.uri).length > 0, { timeout: 5000 });
 
 		// Check the result.
 		t.deepEqual(
-			languages.getDiagnostics(mdDocument.uri).map(normalizeDiagnostic),
+			getStylelintDiagnostics(mdDocument.uri).map(normalizeDiagnostic),
 			[
 				{
 					range: { start: { line: 4, character: 2 }, end: { line: 4, character: 2 } },

--- a/test/ws-report-invalid-scope-disables-test/index.js
+++ b/test/ws-report-invalid-scope-disables-test/index.js
@@ -3,8 +3,8 @@
 const path = require('path');
 const pWaitFor = require('p-wait-for');
 const test = require('tape');
-const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
-const { normalizeDiagnostic } = require('../utils');
+const { extensions, workspace, window, Uri, commands } = require('vscode');
+const { normalizeDiagnostic, getStylelintDiagnostics } = require('../utils');
 
 const run = () =>
 	test('vscode-stylelint with "stylelint.reportInvalidScopeDisables"', async (t) => {
@@ -19,10 +19,10 @@ const run = () =>
 
 		// Wait for diagnostics result.
 		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
-		await pWaitFor(() => languages.getDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+		await pWaitFor(() => getStylelintDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
 
 		// Check the result.
-		const diagnostics = languages.getDiagnostics(cssDocument.uri);
+		const diagnostics = getStylelintDiagnostics(cssDocument.uri);
 
 		t.deepEqual(
 			diagnostics.map(normalizeDiagnostic),

--- a/test/ws-report-needless-disables-test/index.js
+++ b/test/ws-report-needless-disables-test/index.js
@@ -3,8 +3,8 @@
 const path = require('path');
 const pWaitFor = require('p-wait-for');
 const test = require('tape');
-const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
-const { normalizeDiagnostic } = require('../utils');
+const { extensions, workspace, window, Uri, commands } = require('vscode');
+const { normalizeDiagnostic, getStylelintDiagnostics } = require('../utils');
 
 const run = () =>
 	test('vscode-stylelint with "stylelint.reportNeedlessDisables"', async (t) => {
@@ -19,10 +19,10 @@ const run = () =>
 
 		// Wait for diagnostics result.
 		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
-		await pWaitFor(() => languages.getDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+		await pWaitFor(() => getStylelintDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
 
 		// Check the result.
-		const diagnostics = languages.getDiagnostics(cssDocument.uri);
+		const diagnostics = getStylelintDiagnostics(cssDocument.uri);
 
 		t.deepEqual(
 			diagnostics.map(normalizeDiagnostic),

--- a/test/ws-rule-doc-test/index.js
+++ b/test/ws-rule-doc-test/index.js
@@ -3,8 +3,8 @@
 const path = require('path');
 const pWaitFor = require('p-wait-for');
 const test = require('tape');
-const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
-const { normalizeDiagnostic } = require('../utils');
+const { extensions, workspace, window, Uri, commands } = require('vscode');
+const { normalizeDiagnostic, getStylelintDiagnostics } = require('../utils');
 
 const run = () =>
 	test('vscode-stylelint lint test', async (t) => {
@@ -19,19 +19,11 @@ const run = () =>
 
 		// Wait for diagnostics result.
 		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
-		await pWaitFor(
-			() =>
-				languages.getDiagnostics(cssDocument.uri).filter((d) => d.source === 'stylelint').length >
-				0,
-			{ timeout: 5000 },
-		);
+		await pWaitFor(() => getStylelintDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
 
 		// Check the result.
 		t.deepEqual(
-			languages
-				.getDiagnostics(cssDocument.uri)
-				.filter((d) => d.source === 'stylelint')
-				.map(normalizeDiagnostic),
+			getStylelintDiagnostics(cssDocument.uri).map(normalizeDiagnostic),
 			[
 				{
 					range: { start: { line: 0, character: 5 }, end: { line: 0, character: 5 } },

--- a/test/ws-stylelint-path-test/index.js
+++ b/test/ws-stylelint-path-test/index.js
@@ -3,8 +3,8 @@
 const path = require('path');
 const pWaitFor = require('p-wait-for');
 const test = require('tape');
-const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
-const { normalizeDiagnostic } = require('../utils');
+const { extensions, workspace, window, Uri, commands } = require('vscode');
+const { normalizeDiagnostic, getStylelintDiagnostics } = require('../utils');
 
 const run = () =>
 	test('vscode-stylelint with "stylelint.stylelintPath"', async (t) => {
@@ -19,10 +19,10 @@ const run = () =>
 
 		// Wait for diagnostics result.
 		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
-		await pWaitFor(() => languages.getDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+		await pWaitFor(() => getStylelintDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
 
 		// Check the result.
-		const diagnostics = languages.getDiagnostics(cssDocument.uri);
+		const diagnostics = getStylelintDiagnostics(cssDocument.uri);
 
 		t.deepEqual(
 			diagnostics.map(normalizeDiagnostic),

--- a/test/ws-syntax-test/.vscode/settings.json
+++ b/test/ws-syntax-test/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"stylelint.syntax": "sass"
+}

--- a/test/ws-syntax-test/index.js
+++ b/test/ws-syntax-test/index.js
@@ -3,8 +3,8 @@
 const path = require('path');
 const pWaitFor = require('p-wait-for');
 const test = require('tape');
-const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
-const { normalizeDiagnostic } = require('../utils');
+const { extensions, workspace, window, Uri, commands } = require('vscode');
+const { normalizeDiagnostic, getStylelintDiagnostics } = require('../utils');
 
 const run = () =>
 	test('vscode-stylelint with "stylelint.syntax"', async (t) => {
@@ -19,10 +19,10 @@ const run = () =>
 
 		// Wait for diagnostics result.
 		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
-		await pWaitFor(() => languages.getDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+		await pWaitFor(() => getStylelintDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
 
 		// Check the result.
-		const diagnostics = languages.getDiagnostics(cssDocument.uri);
+		const diagnostics = getStylelintDiagnostics(cssDocument.uri);
 
 		t.deepEqual(
 			diagnostics.map(normalizeDiagnostic),

--- a/test/ws-syntax-test/index.js
+++ b/test/ws-syntax-test/index.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const path = require('path');
+const pWaitFor = require('p-wait-for');
+const test = require('tape');
+const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
+const { normalizeDiagnostic } = require('../utils');
+
+const run = () =>
+	test('vscode-stylelint with "stylelint.syntax"', async (t) => {
+		await commands.executeCommand('vscode.openFolder', Uri.file(__dirname));
+
+		const vscodeStylelint = extensions.getExtension('stylelint.vscode-stylelint');
+
+		// Open the './test.css' file.
+		const cssDocument = await workspace.openTextDocument(path.resolve(__dirname, 'test.css'));
+
+		await window.showTextDocument(cssDocument);
+
+		// Wait for diagnostics result.
+		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
+		await pWaitFor(() => languages.getDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+
+		// Check the result.
+		const diagnostics = languages.getDiagnostics(cssDocument.uri);
+
+		t.deepEqual(
+			diagnostics.map(normalizeDiagnostic),
+			[
+				{
+					range: { start: { line: 2, character: 2 }, end: { line: 2, character: 2 } },
+					message: 'Expected indentation of 4 spaces (indentation)',
+					severity: 0,
+					code: {
+						value: 'indentation',
+						target: {
+							scheme: 'https',
+							authority: 'stylelint.io',
+							path: '/user-guide/rules/indentation',
+						},
+					},
+					source: 'stylelint',
+				},
+			],
+			'should work even if "stylelint.syntax" is defined.',
+		);
+
+		t.end();
+	});
+
+exports.run = (root, done) => {
+	test.onFinish(done);
+	run();
+};

--- a/test/ws-syntax-test/stylelint.config.js
+++ b/test/ws-syntax-test/stylelint.config.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+	rules: {
+		indentation: [4],
+	},
+};

--- a/test/ws-syntax-test/test.css
+++ b/test/ws-syntax-test/test.css
@@ -1,0 +1,3 @@
+/* prettier-ignore */
+a
+  color: #fff;

--- a/test/ws-validate-test/index.js
+++ b/test/ws-validate-test/index.js
@@ -3,8 +3,8 @@
 const path = require('path');
 const pWaitFor = require('p-wait-for');
 const test = require('tape');
-const { extensions, workspace, window, Uri, commands, languages } = require('vscode');
-const { normalizeDiagnostic } = require('../utils');
+const { extensions, workspace, window, Uri, commands } = require('vscode');
+const { normalizeDiagnostic, getStylelintDiagnostics } = require('../utils');
 
 const run = () =>
 	test('vscode-stylelint with "stylelint.validate"', async (t) => {
@@ -32,7 +32,7 @@ const run = () =>
 		await new Promise((resolve) => setTimeout(resolve, 2000));
 
 		// Check the result.
-		t.deepEqual(languages.getDiagnostics(cssDocument.uri), [], 'should be ignored lint on css.');
+		t.deepEqual(getStylelintDiagnostics(cssDocument.uri), [], 'should be ignored lint on css.');
 
 		// Execute the Autofix command.
 		await commands.executeCommand('stylelint.executeAutofix');
@@ -50,11 +50,11 @@ const run = () =>
 		await window.showTextDocument(scssDocument);
 
 		// Wait for diagnostics result.
-		await pWaitFor(() => languages.getDiagnostics(scssDocument.uri).length > 0, { timeout: 5000 });
+		await pWaitFor(() => getStylelintDiagnostics(scssDocument.uri).length > 0, { timeout: 5000 });
 
 		// Check the result.
 		t.deepEqual(
-			languages.getDiagnostics(scssDocument.uri).map(normalizeDiagnostic),
+			getStylelintDiagnostics(scssDocument.uri).map(normalizeDiagnostic),
 			[
 				{
 					range: { start: { line: 2, character: 2 }, end: { line: 2, character: 2 } },
@@ -93,11 +93,7 @@ const run = () =>
 		await new Promise((resolve) => setTimeout(resolve, 2000));
 
 		// Check the result.
-		t.deepEqual(
-			languages.getDiagnostics(mdDocument.uri),
-			[],
-			'should be ignored lint on markdown.',
-		);
+		t.deepEqual(getStylelintDiagnostics(mdDocument.uri), [], 'should be ignored lint on markdown.');
 
 		// Execute the Autofix command.
 		await commands.executeCommand('stylelint.executeAutofix');


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #38.  
**Note:** #38 can be closed if #117 and #118 are also merged.

> Is there anything in the PR that needs further explanation?

This PR adds the `"stylelint.syntax"` option.
The `"stylelint.syntax"` option is passed to the `syntax` option in stylelint's Node.js API.
