### PR TITLE
Change the supported version of vscode to ">=1.43.0".

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -394,9 +394,9 @@
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
     "@types/vscode": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.45.1.tgz",
-      "integrity": "sha512-0NO9qrrEJBO8FsqHCrFMgR2suKnwCsKBWvRSb2OzH5gs4i3QO5AhEMQYrSzDbU/wLPt7N617/rN9lPY213gmwg==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.43.0.tgz",
+      "integrity": "sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==",
       "dev": true
     },
     "@typescript-eslint/experimental-utils": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "qna": "https://stackoverflow.com/questions/tagged/vscode+stylelint",
   "icon": "media/stylelint.png",
   "engines": {
-    "vscode": ">=1.41.0",
+    "vscode": ">=1.43.0",
     "node": ">=10.2.0"
   },
   "galleryBanner": {
@@ -209,7 +209,7 @@
     "@types/path-is-inside": "^1.0.0",
     "@types/stylelint": "^9.10.1",
     "@types/tape": "^4.13.0",
-    "@types/vscode": "^1.45.1",
+    "@types/vscode": "1.43.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-config-stylelint": "^11.1.0",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to https://github.com/stylelint/vscode-stylelint/issues/120#issuecomment-640957765

> Is there anything in the PR that needs further explanation?

- Change the version of `engines.vscode` from ">=1.41.0" to ">=1.43.0".
  This version is a supported version of complex diagnostic codes. Use complex diagnostic codes in documentation links: #86
- Downgrade the version of `@types/vscode` from "^1.45.1" to "1.43.0"
  Match the versions so that we can build.
