### PR TITLE
Fix svelte vscode extension link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Once a user follows [the stylelint startup guide](https://stylelint.io/user-guid
   - [Official (`source.css.styled`)](https://marketplace.visualstudio.com/items?itemName=jpoissonnier.vscode-styled-components)
   - [Userland (`styled-css`)](https://marketplace.visualstudio.com/items?itemName=mgmcdermott.vscode-language-babel)
 - [Sugarss (`sugarss`)](https://marketplace.visualstudio.com/items?itemName=mhmadhamster.postcss-language)
-- [Svelte (`svelte`)](https://marketplace.visualstudio.com/items?itemName=JamesBirtles.svelte-vscode)
+- [Svelte (`svelte`)](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode)
 - TypeScript (`typescript`)
 - TypeScript React (`typescriptreact`)
 - [Vue (`vue`, `vue-html`, `vue-postcss`)](https://marketplace.visualstudio.com/items?itemName=octref.vetur)


### PR DESCRIPTION
It linked to the old one which is no longer deployed. This updates the link to the new, official extension.

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
