### PR TITLE
Add stylelint.configFile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Default: `""`
 
 Set stylelint [`configFile`](https://stylelint.io/user-guide/usage/options#configfile) option. Path to a JSON, YAML, or JS file that contains your configuration object. Use this option if you don't want stylelint to search for a configuration file.
 
-
 #### stylelint.configBasedir
 
 Type: `string`  

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Default: `null`
 
 Set stylelint [`config`](https://stylelint.io/user-guide/usage/node-api#config) option. Note that when this option is enabled, stylelint doesn't load configuration files.
 
+#### stylelint.configFile
+
+Type: `string`  
+Default: `""`
+
+Set stylelint [`configFile`](https://stylelint.io/user-guide/usage/options#configfile) option. Path to a JSON, YAML, or JS file that contains your configuration object. Use this option if you don't want stylelint to search for a configuration file.
+
+
 #### stylelint.configBasedir
 
 Type: `string`  

--- a/package.json
+++ b/package.json
@@ -56,12 +56,12 @@
           ],
           "default": null,
           "description": "A stylelint configuration object."
-		},
-		"stylelint.configFile": {
-			"type": "string",
-			"default": "",
-			"description": "Path to a JSON, YAML, or JS file that contains your configuration object. Use this option if you don't want stylelint to search for a configuration file."
-		},
+        },
+        "stylelint.configFile": {
+          "type": "string",
+          "default": "",
+          "description": "Path to a JSON, YAML, or JS file that contains your configuration object. Use this option if you don't want stylelint to search for a configuration file."
+        },
         "stylelint.configOverrides": {
           "type": [
             "object",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,12 @@
           ],
           "default": null,
           "description": "A stylelint configuration object."
-        },
+		},
+		"stylelint.configFile": {
+			"type": "string",
+			"default": "",
+			"description": "Path to a JSON, YAML, or JS file that contains your configuration object. Use this option if you don't want stylelint to search for a configuration file."
+		},
         "stylelint.configOverrides": {
           "type": [
             "object",

--- a/test/ws-config-file-test/.vscode/settings.json
+++ b/test/ws-config-file-test/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"stylelint.configFile": "${workspaceFolder}/config-folder/stylelint.config.js"
+}

--- a/test/ws-config-file-test/config-folder/stylelint.config.js
+++ b/test/ws-config-file-test/config-folder/stylelint.config.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+	rules: {
+		indentation: [4],
+		'color-hex-case': ['upper'],
+	},
+};

--- a/test/ws-config-file-test/index.js
+++ b/test/ws-config-file-test/index.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const path = require('path');
+const pWaitFor = require('p-wait-for');
+const test = require('tape');
+const { extensions, workspace, window, Uri, commands } = require('vscode');
+const { normalizeDiagnostic, getStylelintDiagnostics } = require('../utils');
+
+const run = () =>
+	test('vscode-stylelint with "stylelint.configFile"', async (t) => {
+		await commands.executeCommand('vscode.openFolder', Uri.file(__dirname));
+
+		const vscodeStylelint = extensions.getExtension('stylelint.vscode-stylelint');
+
+		// Open the './test.css' file.
+		const cssDocument = await workspace.openTextDocument(path.resolve(__dirname, 'test.css'));
+
+		await window.showTextDocument(cssDocument);
+
+		// Wait for diagnostics result.
+		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
+		await pWaitFor(() => getStylelintDiagnostics(cssDocument.uri).length > 0, { timeout: 5000 });
+
+		// Check the result.
+		const diagnostics = getStylelintDiagnostics(cssDocument.uri);
+
+		t.deepEqual(
+			diagnostics.map(normalizeDiagnostic),
+			[
+				{
+					range: { start: { line: 2, character: 9 }, end: { line: 2, character: 9 } },
+					message: 'Expected "#fff" to be "#FFF" (color-hex-case)',
+					severity: 0,
+					code: {
+						value: 'color-hex-case',
+						target: {
+							scheme: 'https',
+							authority: 'stylelint.io',
+							path: '/user-guide/rules/color-hex-case',
+						},
+					},
+					source: 'stylelint',
+				},
+				{
+					range: { start: { line: 2, character: 2 }, end: { line: 2, character: 2 } },
+					message: 'Expected indentation of 4 spaces (indentation)',
+					severity: 0,
+					code: {
+						value: 'indentation',
+						target: {
+							scheme: 'https',
+							authority: 'stylelint.io',
+							path: '/user-guide/rules/indentation',
+						},
+					},
+					source: 'stylelint',
+				},
+			],
+			'should work even if "stylelint.configFile" is defined.',
+		);
+
+		t.end();
+	});
+
+exports.run = (root, done) => {
+	test.onFinish(done);
+	run();
+};

--- a/test/ws-config-file-test/test.css
+++ b/test/ws-config-file-test/test.css
@@ -1,0 +1,4 @@
+/* prettier-ignore */
+a {
+  color: #fff;
+}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #127

> Is there anything in the PR that needs further explanation?

This PR adds the "stylelint.configFile" option.
The "stylelint.configFile" option is passed to the configFile option in stylelint's Node.js API.