### PR TITLE
Update status badges for "Test", "Lint" actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # vscode-stylelint
 
-[![Build Status](https://travis-ci.com/stylelint/vscode-stylelint.svg?branch=master)](https://travis-ci.com/stylelint/vscode-stylelint)
+![Testing](https://github.com/stylelint/vscode-stylelint/workflows/Testing/badge.svg)
+![Linting](https://github.com/stylelint/vscode-stylelint/workflows/Linting/badge.svg)
 
 A [Visual Studio Code](https://code.visualstudio.com/) extension to lint [CSS](https://www.w3.org/Style/CSS/)/[SCSS](https://sass-lang.com/documentation/syntax)/[Less](http://lesscss.org/) with [stylelint](https://stylelint.io/)
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

Excited that we moved to GitHub Actions in #167! This PR just updates our status badges on the `README` to use the new actions, rather than the (now defunct) Travis CI build.

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
