### PR TITLE
Add support for Format Document action

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
 'use strict';
 
-const { LanguageClient, SettingMonitor, ExecuteCommandRequest } = require('vscode-languageclient');
-const { workspace, commands: Commands, window: Window } = require('vscode');
+const {
+	LanguageClient,
+	SettingMonitor,
+	ExecuteCommandRequest,
+	DocumentFormattingRequest,
+	TextDocumentIdentifier,
+} = require('vscode-languageclient');
+const { workspace, commands: Commands, window: Window, languages: Languages } = require('vscode');
 
 /**
  * @typedef {import('vscode').ExtensionContext} ExtensionContext
@@ -36,6 +42,69 @@ exports.activate = ({ subscriptions }) => {
 			},
 		},
 	);
+
+	client.onReady().then(() => {
+		/**
+		 * Map of registered formatters by language ID.
+		 * @type {Map<string, { dispose(): any }>}
+		 */
+		const registeredFormatters = new Map();
+
+		client.onNotification('stylelint/languageIdsAdded', (/** @type {string[]} */ langIds) => {
+			for (const langId of langIds) {
+				// Avoid registering another formatter if we already registered one for the same language ID.
+				if (registeredFormatters.has(langId)) {
+					return;
+				}
+
+				const formatter = Languages.registerDocumentFormattingEditProvider(langId, {
+					provideDocumentFormattingEdits(textDocument, options) {
+						const params = {
+							textDocument: TextDocumentIdentifier.create(textDocument.uri.toString()),
+							options, // Editor formatting options, overriden by stylelint config.
+						};
+
+						// Request that the language server formats the document.
+						return client
+							.sendRequest(DocumentFormattingRequest.type, params)
+							.then(undefined, () => {
+								Window.showErrorMessage(
+									'Failed to format the document using stylelint. Please consider opening an issue with steps to reproduce.',
+								);
+
+								return null;
+							});
+					},
+				});
+
+				// Keep track of the new formatter.
+				registeredFormatters.set(langId, formatter);
+			}
+		});
+
+		client.onNotification('stylelint/languageIdsRemoved', (/** @type {string[]} */ langIds) => {
+			for (const langId of langIds) {
+				const formatter = registeredFormatters.get(langId);
+
+				if (!formatter) {
+					return;
+				}
+
+				// Unregisters formatter.
+				formatter.dispose();
+				registeredFormatters.delete(langId);
+			}
+		});
+
+		// Make sure that formatters are disposed when extension is unloaded.
+		subscriptions.push({
+			dispose() {
+				for (const formatter of registeredFormatters.values()) {
+					formatter.dispose();
+				}
+			},
+		});
+	});
 
 	subscriptions.push(
 		Commands.registerCommand('stylelint.executeAutofix', async () => {

--- a/test/ws-formatter-test/.vscode/settings.json
+++ b/test/ws-formatter-test/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+	"[css]": {
+		"editor.defaultFormatter": "stylelint.vscode-stylelint"
+	}
+}

--- a/test/ws-formatter-test/index.js
+++ b/test/ws-formatter-test/index.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const fs = require('fs/promises');
+const path = require('path');
+
+const pWaitFor = require('p-wait-for');
+const test = require('tape');
+const { extensions, workspace, Uri, commands, window } = require('vscode');
+
+const run = () =>
+	test('vscode-stylelint', async (t) => {
+		const expectedCss = await fs.readFile(path.resolve(__dirname, 'test.expected.css'), 'utf8');
+
+		await commands.executeCommand('vscode.openFolder', Uri.file(__dirname));
+
+		const vscodeStylelint = extensions.getExtension('stylelint.vscode-stylelint');
+
+		// Open the './test.input.css' file.
+		const cssDocument = await workspace.openTextDocument(path.resolve(__dirname, 'test.input.css'));
+
+		await window.showTextDocument(cssDocument);
+
+		await commands.executeCommand('editor.action.indentUsingTabs', {
+			tabSize: 4,
+			indentSize: 4,
+			insertSpaces: false,
+		});
+
+		await pWaitFor(() => vscodeStylelint.isActive, { timeout: 2000 });
+
+		await commands.executeCommand('editor.action.formatDocument');
+
+		t.equal(cssDocument.getText(), expectedCss, 'should format document using formatting options.');
+
+		t.end();
+	});
+
+exports.run = (root, done) => {
+	test.onFinish(done);
+	run();
+};

--- a/test/ws-formatter-test/test.expected.css
+++ b/test/ws-formatter-test/test.expected.css
@@ -1,0 +1,3 @@
+a {
+	color: red;
+}

--- a/test/ws-formatter-test/test.input.css
+++ b/test/ws-formatter-test/test.input.css
@@ -1,0 +1,3 @@
+a {
+  color: red;
+}


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #25.

> Is there anything in the PR that needs further explanation?

The language server has existing functionality checking when language IDs are removed from configuration (`connection.onDidChangeConfiguration`). This implementation adds a check for added language IDs and sends the client a notification when IDs are added or removed using the notification methods `stylelint/languageIdsAdded` and `stylelint/languageIdsRemoved`.

When the client receives these notifications, it registers or unregisters, as appropriate, a document formatting edit provider with VS Code for the given language IDs. When the provider is asked to provide formatting edits, it sends a `DocumentFormattingRequest` to the language server and returns the result.

When the server receives a document formatting request, it passes the document and VS Code's formatting options to `getFixes`. `getFixes` now supports a second parameter accepting formatting options. When formatting options are provided, `getFixes` translates the options to their respective stylelint rules and sets these rules to the base configuration passed to `buildStylelintOptions`. The only formatting option without a corresponding rule is `trimFinalNewlines`, so it is ignored.

A new test has been added, `ws-formatter-test`. It runs the Format Document action on test CSS after setting indentation settings in VS Code. The test succeeds if the resulting CSS matches the expected formatted output.
