### PR TITLE
Change `activationEvents` to `onStartupFinished`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-stylelint",
-  "version": "0.86.0",
+  "version": "0.87.0",
   "license": "MIT",
   "description": "Modern CSS/SCSS/Less linter",
   "main": "index.js",
@@ -37,7 +37,7 @@
     "check"
   ],
   "activationEvents": [
-    "*"
+    "onStartupFinished"
   ],
   "contributes": {
     "configuration": {


### PR DESCRIPTION
This will remove stylelint as a blocking extension on startup.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

This is related to issue #214 .

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory
