### PR TITLE
fix: add syntax entry points to fix lazy load bug

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/* eslint-disable eslint-comments/disable-enable-pair */
+/* eslint-disable no-process-exit */
+/* eslint-disable node/no-unpublished-require */
+
+const fs = require('fs-extra');
+const esbuild = require('esbuild');
+const glob = require('fast-glob');
+
+const args = new Set(process.argv.slice(2));
+
+async function bundle() {
+	const entryPoints = [
+		'index.js',
+		'server.js',
+		// Necessary because bundler cannot recognize lazy loads in
+		// https://github.com/stylelint/stylelint/blob/13.13.1/lib/syntaxes/index.js#L9-L15
+		...(await glob('node_modules/stylelint/lib/syntaxes/syntax-*.js')),
+	];
+
+	for (const path of await glob('dist/*')) {
+		await fs.remove(path);
+	}
+
+	try {
+		await esbuild.build({
+			entryPoints,
+			entryNames: '[name]',
+			bundle: true,
+			outdir: 'dist',
+			external: ['vscode'],
+			format: 'cjs',
+			platform: 'node',
+			logLevel: 'info',
+			watch: args.has('--watch'),
+			sourcemap: args.has('--sourcemap'),
+			minify: args.has('--minify'),
+		});
+	} catch {
+		process.exit(1);
+	}
+}
+
+bundle();

--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
   },
   "scripts": {
     "ci:download-vscode": "node ci-download-vscode.js",
-    "bundle-base": "esbuild ./index.js ./server.js --bundle --outdir=dist --external:vscode --format=cjs --platform=node",
+    "bundle-base": "node bundle.js",
     "bundle": "npm run bundle-base -- --sourcemap",
     "bundle-watch": "npm run bundle-base -- --sourcemap --watch",
     "format": "prettier . --write",


### PR DESCRIPTION
Fixes #237

The bundler cannot recognize the requires in the stylelint library for syntaxes, due to the lazy loads in the form `importLazy('package')` obscuring the require that is taking place.

This patch adds each syntax as its own entry point to bypass this limitation. It will no longer be necessary when targeting stylelint 14.

see: https://github.com/stylelint/stylelint/blob/13.13.1/lib/syntaxes/index.js