### PR TITLE
fix: use postcss-syntax fork until 1.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "lodash": "^4.17.20",
         "path-is-inside": "^1.0.2",
         "pkg-dir": "^5.0.0",
+        "postcss-syntax": "adalinesimonian/postcss-syntax#bundler-friendly",
         "stylelint": "^13.13.1",
         "vscode-languageclient": "^6.2.0-next.1",
         "vscode-languageserver": "^6.2.0-next.1",
@@ -1841,7 +1842,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-1.0.1.tgz",
       "integrity": "sha1-FXxCOCZfXPlKHf/ehkRlUsvz9wU=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -6267,7 +6268,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-1.0.1.tgz",
       "integrity": "sha512-smhUUMF5o5W1ZCQSyh5A3lNOXFLdNrxqyhWbLsGolZH2AgVmlyhxhYbIixfsdKE6r1vG5i7O40DPcvEvE1mvjw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "camelcase-css": "^1.0.1",
         "postcss": "^6.0.11"
@@ -6277,7 +6278,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -6289,7 +6290,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -6303,7 +6304,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -6312,13 +6313,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/postcss-js/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -6327,7 +6328,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }
@@ -6336,7 +6337,7 @@
       "version": "6.0.23",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
       "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "chalk": "^2.4.1",
         "source-map": "^0.6.1",
@@ -6350,7 +6351,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -6394,7 +6395,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.5.0.tgz",
       "integrity": "sha512-qtu8awh1NMF3o9j/x9j3EZnd+BlF66X6NZYl12BdKoG2Z4hmydOt/dZj2Nq+g0kfk2pQy3jeYFBmvG9DBwynGQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "gonzales-pe": "^4.3.0",
         "postcss": "^8.2.14"
@@ -6407,7 +6408,7 @@
       "version": "3.1.25",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
       "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6419,7 +6420,7 @@
       "version": "8.3.7",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.7.tgz",
       "integrity": "sha512-9SaY7nnyQ63/WittqZYAvkkYPyKxchMKH71UDzeTmWuLSvxTRpeEeABZAzlCi55cuGcoFyoV/amX2BdsafQidQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "nanocolors": "^0.1.5",
         "nanoid": "^3.1.25",
@@ -6458,10 +6459,48 @@
     },
     "node_modules/postcss-syntax": {
       "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
-      "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
+      "resolved": "git+ssh://git@github.com/adalinesimonian/postcss-syntax.git#ba1d4a60d5a8a68d171c35df23393d2886107152",
+      "license": "MIT",
       "peerDependencies": {
-        "postcss": ">=5.0.0"
+        "@stylelint/postcss-css-in-js": "*",
+        "@stylelint/postcss-markdown": "*",
+        "postcss": ">=5.0.0",
+        "postcss-html": "*",
+        "postcss-js": "*",
+        "postcss-less": "*",
+        "postcss-safe-parser": "*",
+        "postcss-sass": "*",
+        "postcss-scss": "*",
+        "sugarss": "*"
+      },
+      "peerDependenciesMeta": {
+        "@stylelint/postcss-css-in-js": {
+          "optional": true
+        },
+        "@stylelint/postcss-markdown": {
+          "optional": true
+        },
+        "postcss-html": {
+          "optional": true
+        },
+        "postcss-js": {
+          "optional": true
+        },
+        "postcss-less": {
+          "optional": true
+        },
+        "postcss-safe-parser": {
+          "optional": true
+        },
+        "postcss-sass": {
+          "optional": true
+        },
+        "postcss-scss": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        }
       }
     },
     "node_modules/postcss-value-parser": {
@@ -7168,7 +7207,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
       "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9796,7 +9835,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-1.0.1.tgz",
       "integrity": "sha1-FXxCOCZfXPlKHf/ehkRlUsvz9wU=",
-      "dev": true
+      "devOptional": true
     },
     "camelcase-keys": {
       "version": "6.2.2",
@@ -13097,7 +13136,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-1.0.1.tgz",
       "integrity": "sha512-smhUUMF5o5W1ZCQSyh5A3lNOXFLdNrxqyhWbLsGolZH2AgVmlyhxhYbIixfsdKE6r1vG5i7O40DPcvEvE1mvjw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "camelcase-css": "^1.0.1",
         "postcss": "^6.0.11"
@@ -13107,7 +13146,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -13116,7 +13155,7 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -13127,7 +13166,7 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -13136,25 +13175,25 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "devOptional": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "devOptional": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "devOptional": true
         },
         "postcss": {
           "version": "6.0.23",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "chalk": "^2.4.1",
             "source-map": "^0.6.1",
@@ -13165,7 +13204,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -13202,7 +13241,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.5.0.tgz",
       "integrity": "sha512-qtu8awh1NMF3o9j/x9j3EZnd+BlF66X6NZYl12BdKoG2Z4hmydOt/dZj2Nq+g0kfk2pQy3jeYFBmvG9DBwynGQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "gonzales-pe": "^4.3.0",
         "postcss": "^8.2.14"
@@ -13212,13 +13251,13 @@
           "version": "3.1.25",
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
           "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
-          "dev": true
+          "devOptional": true
         },
         "postcss": {
           "version": "8.3.7",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.7.tgz",
           "integrity": "sha512-9SaY7nnyQ63/WittqZYAvkkYPyKxchMKH71UDzeTmWuLSvxTRpeEeABZAzlCi55cuGcoFyoV/amX2BdsafQidQ==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "nanocolors": "^0.1.5",
             "nanoid": "^3.1.25",
@@ -13245,9 +13284,8 @@
       }
     },
     "postcss-syntax": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
-      "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
+      "version": "git+ssh://git@github.com/adalinesimonian/postcss-syntax.git#ba1d4a60d5a8a68d171c35df23393d2886107152",
+      "from": "postcss-syntax@adalinesimonian/postcss-syntax#bundler-friendly",
       "requires": {}
     },
     "postcss-value-parser": {
@@ -13717,7 +13755,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
       "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
-      "dev": true
+      "devOptional": true
     },
     "source-map-support": {
       "version": "0.5.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.20",
         "path-is-inside": "^1.0.2",
         "pkg-dir": "^5.0.0",
-        "postcss-syntax": "git+https://github.com/adalinesimonian/postcss-syntax.git#bundler-friendly",
+        "postcss-syntax": "https://git@github.com/adalinesimonian/postcss-syntax.git#bundler-friendly",
         "stylelint": "^13.13.1",
         "vscode-languageclient": "^6.2.0-next.1",
         "vscode-languageserver": "^6.2.0-next.1",
@@ -6459,7 +6459,7 @@
     },
     "node_modules/postcss-syntax": {
       "version": "0.36.2",
-      "resolved": "git+ssh://git@github.com/adalinesimonian/postcss-syntax.git#ba1d4a60d5a8a68d171c35df23393d2886107152",
+      "resolved": "git+https://git@github.com/adalinesimonian/postcss-syntax.git#ba1d4a60d5a8a68d171c35df23393d2886107152",
       "license": "MIT",
       "peerDependencies": {
         "@stylelint/postcss-css-in-js": "*",
@@ -13284,8 +13284,8 @@
       }
     },
     "postcss-syntax": {
-      "version": "git+ssh://git@github.com/adalinesimonian/postcss-syntax.git#ba1d4a60d5a8a68d171c35df23393d2886107152",
-      "from": "postcss-syntax@git+https://github.com/adalinesimonian/postcss-syntax.git#bundler-friendly",
+      "version": "git+https://git@github.com/adalinesimonian/postcss-syntax.git#ba1d4a60d5a8a68d171c35df23393d2886107152",
+      "from": "postcss-syntax@https://git@github.com/adalinesimonian/postcss-syntax.git#bundler-friendly",
       "requires": {}
     },
     "postcss-value-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.20",
         "path-is-inside": "^1.0.2",
         "pkg-dir": "^5.0.0",
-        "postcss-syntax": "adalinesimonian/postcss-syntax#bundler-friendly",
+        "postcss-syntax": "git+https://github.com/adalinesimonian/postcss-syntax.git#bundler-friendly",
         "stylelint": "^13.13.1",
         "vscode-languageclient": "^6.2.0-next.1",
         "vscode-languageserver": "^6.2.0-next.1",
@@ -13285,7 +13285,7 @@
     },
     "postcss-syntax": {
       "version": "git+ssh://git@github.com/adalinesimonian/postcss-syntax.git#ba1d4a60d5a8a68d171c35df23393d2886107152",
-      "from": "postcss-syntax@adalinesimonian/postcss-syntax#bundler-friendly",
+      "from": "postcss-syntax@git+https://github.com/adalinesimonian/postcss-syntax.git#bundler-friendly",
       "requires": {}
     },
     "postcss-value-parser": {

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "fast-diff": "^1.2.0",
     "lodash": "^4.17.20",
     "path-is-inside": "^1.0.2",
-    "postcss-syntax": "git+https://github.com/adalinesimonian/postcss-syntax.git#bundler-friendly",
+    "postcss-syntax": "https://git@github.com/adalinesimonian/postcss-syntax.git#bundler-friendly",
     "pkg-dir": "^5.0.0",
     "stylelint": "^13.13.1",
     "vscode-languageclient": "^6.2.0-next.1",

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "fast-diff": "^1.2.0",
     "lodash": "^4.17.20",
     "path-is-inside": "^1.0.2",
-    "postcss-syntax": "adalinesimonian/postcss-syntax#bundler-friendly",
+    "postcss-syntax": "git+https://github.com/adalinesimonian/postcss-syntax.git#bundler-friendly",
     "pkg-dir": "^5.0.0",
     "stylelint": "^13.13.1",
     "vscode-languageclient": "^6.2.0-next.1",

--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "fast-diff": "^1.2.0",
     "lodash": "^4.17.20",
     "path-is-inside": "^1.0.2",
+    "postcss-syntax": "adalinesimonian/postcss-syntax#bundler-friendly",
     "pkg-dir": "^5.0.0",
     "stylelint": "^13.13.1",
     "vscode-languageclient": "^6.2.0-next.1",


### PR DESCRIPTION
Fixes #239

postcss-syntax uses require statements without string literals, so the bundler is unable to recognize the dependencies at bundle time. This fork uses static requires for packages used in vscode-stylelint to allow the proper resolution of packages.

This fix, along with the fix for #237, will no longer be required for 1.x of this extension, which will be tracking stylelint 14.

See https://github.com/adalinesimonian/postcss-syntax/commit/ba1d4a6