### PR TITLE
refactor: Replace deprecated API usage

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Run lib tests
         run: npm run test:lib -- --coverage
 
+      - name: Run unit tests
+        run: npm run test:unit -- --coverage
+
       - name: Run VS Code tests (Linux)
         if: runner.os == 'Linux'
         run: xvfb-run -a npm run test:workspace -- --silent

--- a/__mocks__/child_process.js
+++ b/__mocks__/child_process.js
@@ -1,0 +1,197 @@
+'use strict';
+
+const stream = require('stream');
+const { createError } = require('../test/mockSystemErrors');
+
+const cp = jest.createMockFromModule('child_process');
+
+/**
+ * Mocks of processes.
+ * @type {{
+ *   [command: string]: {
+ *   args: string[];
+ *   exitCode: number | NodeJS.Signals;
+ *   stdout?: string;
+ *   stderr?: string;
+ *   }[];
+ * }}
+ */
+let processes = {};
+
+/**
+ * Resets the mocked processes.
+ * @return {void}
+ */
+cp.__resetMockedProcesses = () => {
+	processes = {};
+};
+
+const delay = {
+	exit: 0,
+	stdout: 0,
+	stderr: 0,
+	error: 0,
+};
+
+/**
+ * Sets timing of responses to listeners.
+ * @param {number} exitDelay
+ * @param {number} stdoutDelay
+ * @param {number} stderrDelay
+ * @param {number} errorDelay
+ */
+cp.__setDelay = (exitDelay = 0, stdoutDelay = 0, stderrDelay = 0, errorDelay = 0) => {
+	delay.exit = exitDelay;
+	delay.stdout = stdoutDelay;
+	delay.stderr = stderrDelay;
+	delay.error = errorDelay;
+};
+
+/**
+ * Mocks a process.
+ * @param {string} command
+ * @param {string[]} args
+ * @param {number | NodeJS.Signals} exitCode
+ * @param {string} [stdout]
+ * @param {string} [stderr]
+ */
+cp.__mockProcess = (command, args, exitCode, stdout, stderr) => {
+	if (!processes[command]) {
+		processes[command] = [];
+	}
+
+	processes[command].push({
+		args,
+		exitCode,
+		stdout,
+		stderr,
+	});
+};
+
+/**
+ * Finds the mocked process for the given command and arguments. If none is
+ * found, returns `undefined`.
+ * @param {string} command
+ * @param {string[]} args
+ */
+const findMockedProcess = (command, args) => {
+	const variants = processes[command];
+
+	if (!variants) {
+		return undefined;
+	}
+
+	for (const variant of variants) {
+		if (variant.args.length !== args.length) {
+			continue;
+		}
+
+		if (variant.args.every((arg, index) => arg === args[index])) {
+			return variant;
+		}
+	}
+
+	return undefined;
+};
+
+/**
+ * Mock implementation of the `child_process.spawn` function.
+ * @param {string} command
+ * @param {string[]} args
+ * @returns {tests.mocks.ChildProcessWithoutNullStreams}
+ */
+cp.spawn = (command, args) => {
+	const variant = findMockedProcess(command, args);
+
+	/** @type {Error} */
+	let errorToEmit;
+
+	if (!variant) {
+		errorToEmit = createError('ENOENT', command, -4058, `spawn ${command}`);
+	}
+
+	/** @type {tests.mocks.ChildProcessWithoutNullStreams} */
+	const childProcess = {
+		removeAllListeners() {
+			return childProcess;
+		},
+
+		kill() {},
+
+		on(event, listener) {
+			if (event === 'error') {
+				if (errorToEmit) {
+					if (delay.error) {
+						setTimeout(() => {
+							listener(errorToEmit);
+						}, delay.error);
+					} else {
+						listener(errorToEmit);
+					}
+				}
+			} else if (event === 'exit') {
+				if (variant) {
+					const handleExit = () => {
+						if (typeof variant.exitCode === 'number') {
+							listener(variant.exitCode);
+						} else {
+							listener(null, variant.exitCode);
+						}
+					};
+
+					if (delay.exit) {
+						setTimeout(handleExit, delay.exit);
+					} else {
+						handleExit();
+					}
+				}
+			}
+
+			return childProcess;
+		},
+
+		stdout: new stream.Readable({
+			read() {
+				if (delay.stdout) {
+					setTimeout(() => {
+						if (variant?.stdout) {
+							this.push(variant.stdout);
+						}
+
+						this.push(null);
+					}, delay.stdout);
+				} else {
+					if (variant?.stdout) {
+						this.push(variant.stdout);
+					}
+
+					this.push(null);
+				}
+			},
+		}),
+
+		stderr: new stream.Readable({
+			read() {
+				if (delay.stderr) {
+					setTimeout(() => {
+						if (variant?.stderr) {
+							this.push(variant.stderr);
+						}
+
+						this.push(null);
+					}, delay.stderr);
+				} else {
+					if (variant?.stderr) {
+						this.push(variant.stderr);
+					}
+
+					this.push(null);
+				}
+			},
+		}),
+	};
+
+	return childProcess;
+};
+
+module.exports = cp;

--- a/__mocks__/fs/promises.js
+++ b/__mocks__/fs/promises.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const path = require('path');
+const { createError } = require('../../test/mockSystemErrors');
+
+const fs = jest.createMockFromModule('fs/promises');
+
+/**
+ * Mock file system tree for testing.
+ * @type {tests.mocks.FileSystemTree}
+ */
+let mockFileSystem = Object.create(null);
+
+/**
+ * Sets the mock file system tree.
+ * @param {tests.mocks.FileSystemTree} tree
+ * @returns {void}
+ */
+fs.__mockFileSystem = (tree) => {
+	mockFileSystem = tree;
+};
+
+/**
+ * For a given path, returns the mock file system entry.
+ * @param {string} fsPath
+ * @returns {tests.mocks.FileSystemEntry}
+ */
+const getEntry = (fsPath) => {
+	const parts = fsPath.split(path.sep);
+
+	/** @type {tests.mocks.FileSystemEntry} */
+	let entry = mockFileSystem;
+
+	/** @type {string | undefined} */
+	let currentPath = '';
+
+	for (const part of parts) {
+		if (typeof entry === 'string' || entry === undefined) {
+			return undefined;
+		}
+
+		if (entry instanceof Error) {
+			return entry;
+		}
+
+		if (currentPath) {
+			currentPath = path.join(currentPath, part);
+		} else {
+			currentPath = part;
+		}
+
+		entry = entry[part];
+	}
+
+	return entry;
+};
+
+/**
+ * Mock implementation of the `fs.promises.stat` function.
+ * @param {string} fsPath
+ */
+fs.stat = async (fsPath) => {
+	const entry = getEntry(fsPath);
+
+	if (entry === undefined) {
+		throw createError('ENOENT', fsPath, -4058, 'stat');
+	}
+
+	if (entry instanceof Error) {
+		throw entry;
+	}
+
+	if (typeof entry === 'string') {
+		return {
+			isDirectory: () => false,
+			isFile: () => true,
+		};
+	}
+
+	return {
+		isDirectory: () => true,
+		isFile: () => false,
+	};
+};
+
+module.exports = fs;

--- a/__mocks__/os.js
+++ b/__mocks__/os.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const os = jest.createMockFromModule('os');
+
+/**
+ * Mock platform.
+ * @type {NodeJS.Platform}
+ */
+let mockPlatform = 'linux';
+
+/**
+ * Sets the mock platform.
+ * @param {NodeJS.Platform} platform
+ * @returns {void}
+ */
+os.__mockPlatform = (platform) => {
+	mockPlatform = platform;
+};
+
+os.platform = () => mockPlatform;
+
+module.exports = os;

--- a/__mocks__/path.js
+++ b/__mocks__/path.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const path = jest.requireActual('path');
+
+/**
+ * Mock platform.
+ * @type {'posix' | 'win32'}
+ */
+let mockPlatform = 'posix';
+
+/**
+ * Sets the mock platform.
+ * @param {'posix' | 'win32'} platform
+ * @returns {void}
+ */
+const __mockPlatform = (platform) => {
+	mockPlatform = platform;
+};
+
+const pathProxy = new Proxy(path, {
+	get(_, name) {
+		if (name === '__mockPlatform') {
+			return __mockPlatform;
+		}
+
+		if (mockPlatform === 'win32') {
+			if (typeof path.win32[name] === 'function') {
+				return jest.fn(path.win32[name]);
+			}
+
+			return path.win32[name];
+		}
+
+		if (typeof path.posix[name] === 'function') {
+			return jest.fn(path.posix[name]);
+		}
+
+		return path.posix[name];
+	},
+});
+
+module.exports = pathProxy;

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,11 @@
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 const config = {
-	projects: ['<rootDir>/test/lib/jest.config.js', '<rootDir>/test/workspace/jest.config.js'],
+	projects: [
+		'<rootDir>/test/lib/jest.config.js',
+		'<rootDir>/test/unit/jest.config.js',
+		'<rootDir>/test/workspace/jest.config.js',
+	],
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
     "lint:types": "tsc",
     "test": "npm run bundle && jest",
     "test:lib": "jest --projects test/lib",
+    "test:unit": "jest --projects test/unit",
     "test:workspace": "npm run bundle && jest --projects test/workspace",
     "vscode:prepublish": "npm run bundle-base -- --minify"
   },

--- a/src/server.js
+++ b/src/server.js
@@ -5,7 +5,7 @@ const { join, parse, isAbsolute } = require('path');
 const diff = require('fast-diff');
 const parseUri = require('vscode-uri').URI.parse;
 const pathIsInside = require('path-is-inside');
-const { resolvePackageDirectory } = require('./utils');
+const { findPackageRoot } = require('./utils/packages');
 const stylelintVSCode = require('./stylelint-vscode');
 const {
 	createConnection,
@@ -125,7 +125,7 @@ async function buildStylelintOptions(document, baseOptions = {}) {
 
 		if (options.ignorePath === undefined) {
 			options.ignorePath = join(
-				(await resolvePackageDirectory(documentPath)) || parse(documentPath).root,
+				(await findPackageRoot(documentPath)) || parse(documentPath).root,
 				'.stylelintignore',
 			);
 		}

--- a/src/utils/__mocks__/processes.js
+++ b/src/utils/__mocks__/processes.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const processes = jest.createMockFromModule('../processes');
+const { createError } = require('../../../test/mockSystemErrors');
+
+/**
+ * Mocks of processes.
+ * @type {{[command: string]: {args: string[], lines: string[], exitCode?: number}}}
+ */
+let mockProcessMap = {};
+
+/**
+ * Resets the mocked processes.
+ * @return {void}
+ */
+processes.__resetMockedProcesses = () => {
+	mockProcessMap = {};
+};
+
+/**
+ * Mocks a process.
+ * @param {string} command
+ * @param {string[]} args
+ * @param {string[]} lines
+ * @param {number} [exitCode]
+ */
+processes.__mockProcess = (command, args, lines, exitCode) => {
+	mockProcessMap[command] = {
+		args,
+		lines,
+		exitCode,
+	};
+};
+
+/**
+ * Finds the mocked process for the given command and arguments. If none is
+ * found, returns `undefined`.
+ * @param {string} command
+ * @param {string[]} args
+ */
+const findMockedProcess = (command, args) => {
+	const process = mockProcessMap[command];
+
+	if (!process || process.args.length !== args.length) {
+		return undefined;
+	}
+
+	if (process.args.every((arg, index) => arg === args[index])) {
+		return process;
+	}
+
+	return undefined;
+};
+
+/**
+ * Mock implementation of the `utils.runProcessFindLine` function.
+ * @template T
+ * @param {string} command Shell command or path to executable
+ * @param {string[]} args Arguments to pass to the command
+ * @param {import('child_process').SpawnOptionsWithoutStdio | undefined} _options Options to pass to the spawner
+ * @param {(line: string) => (T | undefined)} matcher Function to match the output line
+ * @returns {Promise<T | undefined>}
+ */
+const runProcessFindLine = async (command, args, _options, matcher) => {
+	const process = findMockedProcess(command, args);
+
+	if (!process) {
+		throw createError('ENOENT', command, -4058, `spawn ${command}`);
+	}
+
+	if (process.exitCode !== undefined && process.exitCode !== 0) {
+		throw new Error(`Command "${command}" exited with code ${process.exitCode}.`);
+	}
+
+	for (const line of process.lines) {
+		const result = matcher(line);
+
+		if (result !== undefined) {
+			return result;
+		}
+	}
+
+	return undefined;
+};
+
+processes.runProcessFindLine = jest.fn(runProcessFindLine);
+
+module.exports = processes;

--- a/src/utils/__tests__/__snapshots__/processes.js.snap
+++ b/src/utils/__tests__/__snapshots__/processes.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`runProcessFindLine should throw an error if the command is not found 1`] = `"ENOENT: no such file or directory, open 'foo'"`;
+
+exports[`runProcessFindLine should throw an error if the matcher throws an error before the process exits 1`] = `"error"`;
+
+exports[`runProcessFindLine should throw an error when the process exits due to a signal 1`] = `"Command \\"foo\\" exited with code SIGHUP."`;
+
+exports[`runProcessFindLine should throw an error when the process exits with a non-zero exit code 1`] = `"Command \\"foo\\" exited with code 1."`;

--- a/src/utils/__tests__/processes.js
+++ b/src/utils/__tests__/processes.js
@@ -1,0 +1,76 @@
+'use strict';
+
+jest.mock('child_process');
+
+describe('runProcessFindLine', () => {
+	/** @type {typeof import('../processes').runProcessFindLine} */
+	let runProcessFindLine;
+
+	/** @type {tests.mocks.ChildProcessModule} */
+	let mockedChildProcess;
+
+	beforeAll(() => {
+		mockedChildProcess = /** @type {tests.mocks.ChildProcessModule} */ (require('child_process'));
+
+		mockedChildProcess.__mockProcess('foo', ['bar'], 0, 'from\nstdout');
+		mockedChildProcess.__mockProcess('foo', ['baz'], 0, 'multi\nline\noutput\n');
+		mockedChildProcess.__mockProcess('foo', ['qux'], 1, undefined, 'from\nstderr');
+		mockedChildProcess.__mockProcess('foo', ['quz'], 'SIGHUP', undefined, 'from\nstderr');
+
+		runProcessFindLine = require('../processes').runProcessFindLine;
+	});
+
+	it('should run the process and return the line when it is found', async () => {
+		const result = await runProcessFindLine('foo', ['bar'], undefined, (line) =>
+			line === 'stdout' ? `output: ${line}` : undefined,
+		);
+
+		expect(result).toBe('output: stdout');
+	});
+
+	it('should only return the first matched line', async () => {
+		const result = await runProcessFindLine('foo', ['baz'], undefined, (line) => `output: ${line}`);
+
+		expect(result).toBe('output: multi');
+	});
+
+	it('should throw an error when the process exits with a non-zero exit code', async () => {
+		expect.assertions(1);
+
+		await expect(
+			runProcessFindLine('foo', ['qux'], undefined, (line) =>
+				line === 'stdout' ? `output: ${line}` : undefined,
+			),
+		).rejects.toThrowErrorMatchingSnapshot();
+	});
+
+	it('should throw an error when the process exits due to a signal', async () => {
+		expect.assertions(1);
+
+		await expect(
+			runProcessFindLine('foo', ['quz'], undefined, (line) =>
+				line === 'stdout' ? `output: ${line}` : undefined,
+			),
+		).rejects.toThrowErrorMatchingSnapshot();
+	});
+
+	it('should throw an error if the command is not found', async () => {
+		expect.assertions(1);
+
+		await expect(
+			runProcessFindLine('foo', ['quuz'], undefined, (line) =>
+				line === 'stdout' ? `output: ${line}` : undefined,
+			),
+		).rejects.toThrowErrorMatchingSnapshot();
+	});
+
+	it('should throw an error if the matcher throws an error before the process exits', async () => {
+		expect.assertions(1);
+
+		await expect(
+			runProcessFindLine('foo', ['bar'], undefined, () => {
+				throw new Error('error');
+			}),
+		).rejects.toThrowErrorMatchingSnapshot();
+	});
+});

--- a/src/utils/packages/__tests__/__snapshots__/find-package-root.js.snap
+++ b/src/utils/packages/__tests__/__snapshots__/find-package-root.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`findPackageRoot should throw when encountering a file system error other than ENOENT 1`] = `"EACCES: permission denied, open 'foo/bar/baz'"`;

--- a/src/utils/packages/__tests__/__snapshots__/global-path-resolver.js.snap
+++ b/src/utils/packages/__tests__/__snapshots__/global-path-resolver.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Global Package Manager Path Resolver Error handling Missing commands should throw an error if npm cannot be found 1`] = `"ENOENT: no such file or directory, open 'npm'"`;
+
+exports[`Global Package Manager Path Resolver Error handling Missing commands should throw an error if pnpm cannot be found 1`] = `"ENOENT: no such file or directory, open 'pnpm'"`;
+
+exports[`Global Package Manager Path Resolver Error handling Missing commands should throw an error if yarn cannot be found 1`] = `"ENOENT: no such file or directory, open 'yarn'"`;
+
+exports[`Global Package Manager Path Resolver Error handling Non-zero exit codes should throw an error if npm returns a non-zero exit code 1`] = `"Command \\"npm\\" exited with code 1."`;
+
+exports[`Global Package Manager Path Resolver Error handling Non-zero exit codes should throw an error if pnpm returns a non-zero exit code 1`] = `"Command \\"pnpm\\" exited with code 1."`;
+
+exports[`Global Package Manager Path Resolver Error handling Non-zero exit codes should throw an error if yarn returns a non-zero exit code 1`] = `"Command \\"yarn\\" exited with code 1."`;

--- a/src/utils/packages/__tests__/find-package-root.js
+++ b/src/utils/packages/__tests__/find-package-root.js
@@ -1,0 +1,91 @@
+'use strict';
+
+jest.mock('fs/promises');
+
+const { createError } = require('../../../../test/mockSystemErrors');
+
+describe('findPackageRoot', () => {
+	/** @type {tests.mocks.FSPromisesModule} */
+	let mockedFS;
+
+	/** @type {typeof import('../find-package-root').findPackageRoot} */
+	let findPackageRoot;
+
+	beforeAll(() => {
+		mockedFS = /** @type {tests.mocks.FSPromisesModule} */ (require('fs/promises'));
+		findPackageRoot = require('../find-package-root').findPackageRoot;
+	});
+
+	it('should resolve the package directory when package.json is present', async () => {
+		mockedFS.__mockFileSystem({
+			foo: {
+				bar: {
+					'package.json': '{}',
+					baz: {},
+				},
+			},
+		});
+
+		expect(await findPackageRoot('foo/bar/baz')).toBe('foo/bar');
+	});
+
+	it("should not resolve when package.json isn't in the tree", async () => {
+		mockedFS.__mockFileSystem({
+			foo: {
+				bar: {
+					baz: {},
+				},
+			},
+		});
+
+		expect(await findPackageRoot('foo/bar/baz')).toBeUndefined();
+	});
+
+	it('should not resolve folders with a directory named package.json', async () => {
+		mockedFS.__mockFileSystem({
+			foo: {
+				'package.json': '{}',
+				bar: {
+					'package.json': {},
+					baz: {},
+				},
+			},
+		});
+
+		expect(await findPackageRoot('foo/bar/baz')).toBe('foo');
+
+		mockedFS.__mockFileSystem({
+			foo: {
+				'package.json': {},
+				bar: {
+					baz: {},
+				},
+			},
+		});
+
+		expect(await findPackageRoot('foo/bar/baz')).toBeUndefined();
+
+		mockedFS.__mockFileSystem({
+			'package.json': {},
+			foo: {
+				bar: {
+					baz: {},
+				},
+			},
+		});
+
+		expect(await findPackageRoot('foo/bar/baz')).toBeUndefined();
+	});
+
+	it('should throw when encountering a file system error other than ENOENT', async () => {
+		mockedFS.__mockFileSystem({
+			foo: {
+				bar: {
+					baz: createError('EACCES', 'foo/bar/baz', -13, 'stat'),
+				},
+			},
+		});
+
+		await expect(findPackageRoot('foo/bar/baz')).rejects.toThrowErrorMatchingSnapshot();
+	});
+});

--- a/src/utils/packages/__tests__/global-path-resolver.js
+++ b/src/utils/packages/__tests__/global-path-resolver.js
@@ -1,0 +1,340 @@
+'use strict';
+
+jest.mock('path');
+jest.mock('os');
+jest.mock('../../processes');
+
+/** @typedef {typeof import('../global-path-resolver').getGlobalPathResolver} getGlobalPathResolver */
+
+/**
+ * @param {'posix' | 'win32'} platform
+ */
+const mockPlatform = (platform) => {
+	const mockedOS = /** @type {tests.mocks.OSModule} */ (require('os'));
+
+	mockedOS.__mockPlatform(platform === 'win32' ? 'win32' : 'linux');
+
+	const mockedPath = /** @type {tests.mocks.PathModule} */ (require('path'));
+
+	mockedPath.__mockPlatform(platform);
+};
+
+describe('Global Package Manager Path Resolver', () => {
+	describe('Non-Windows', () => {
+		/** @type {getGlobalPathResolver} */
+		let getGlobalPathResolver;
+
+		beforeAll(() => {
+			mockPlatform('posix');
+
+			const mockedProcesses = /** @type {tests.mocks.Processes} */ (require('../../processes'));
+
+			mockedProcesses.__resetMockedProcesses();
+
+			mockedProcesses.__mockProcess(
+				'yarn',
+				['global', 'dir', '--json'],
+				['{"type":"log","data":"/path/to/yarn/global/dir"}'],
+			);
+
+			mockedProcesses.__mockProcess(
+				'npm',
+				['config', 'get', 'prefix'],
+				['/path/to/npm/global/dir'],
+			);
+
+			mockedProcesses.__mockProcess('pnpm', ['root', '-g'], ['/path/to/pnpm/global/dir']);
+
+			getGlobalPathResolver = require('../global-path-resolver').getGlobalPathResolver;
+		});
+
+		it('should resolve the yarn global package directory', async () => {
+			const resolver = getGlobalPathResolver();
+			const globalPath = await resolver.resolve('yarn');
+
+			expect(globalPath).toBe('/path/to/yarn/global/dir/node_modules');
+		});
+
+		it('should resolve the npm global package directory', async () => {
+			const resolver = getGlobalPathResolver();
+			const globalPath = await resolver.resolve('npm');
+
+			expect(globalPath).toBe('/path/to/npm/global/dir/lib/node_modules');
+		});
+
+		it('should resolve the pnpm global package directory', async () => {
+			const resolver = getGlobalPathResolver();
+			const globalPath = await resolver.resolve('pnpm');
+
+			expect(globalPath).toBe('/path/to/pnpm/global/dir');
+		});
+	});
+
+	describe('Windows', () => {
+		/** @type {getGlobalPathResolver} */
+		let getGlobalPathResolver;
+
+		beforeAll(() => {
+			mockPlatform('win32');
+
+			const mockedProcesses = /** @type {tests.mocks.Processes} */ (require('../../processes'));
+
+			mockedProcesses.__resetMockedProcesses();
+
+			mockedProcesses.__mockProcess(
+				'yarn',
+				['global', 'dir', '--json'],
+				['{"type":"log","data":"C:\\\\path\\\\to\\\\yarn\\\\global\\\\dir"}'],
+			);
+
+			mockedProcesses.__mockProcess(
+				'npm',
+				['config', 'get', 'prefix'],
+				['C:\\path\\to\\npm\\global\\dir'],
+			);
+
+			mockedProcesses.__mockProcess('pnpm', ['root', '-g'], ['C:\\path\\to\\pnpm\\global\\dir']);
+
+			getGlobalPathResolver = require('../global-path-resolver').getGlobalPathResolver;
+		});
+
+		it('should resolve the yarn global package directory', async () => {
+			const resolver = getGlobalPathResolver();
+			const globalPath = await resolver.resolve('yarn');
+
+			expect(globalPath).toBe('C:\\path\\to\\yarn\\global\\dir\\node_modules');
+		});
+
+		it('should resolve the npm global package directory', async () => {
+			const resolver = getGlobalPathResolver();
+			const globalPath = await resolver.resolve('npm');
+
+			expect(globalPath).toBe('C:\\path\\to\\npm\\global\\dir\\node_modules');
+		});
+
+		it('should resolve the pnpm global package directory', async () => {
+			const resolver = getGlobalPathResolver();
+			const globalPath = await resolver.resolve('pnpm');
+
+			expect(globalPath).toBe('C:\\path\\to\\pnpm\\global\\dir');
+		});
+	});
+
+	describe('Caching', () => {
+		/** @type {getGlobalPathResolver} */
+		let getGlobalPathResolver;
+
+		/** @type {tests.mocks.Processes} */
+		let mockedProcesses;
+
+		beforeAll(() => {
+			mockPlatform('posix');
+
+			mockedProcesses = /** @type {tests.mocks.Processes} */ (require('../../processes'));
+
+			mockedProcesses.__resetMockedProcesses();
+
+			mockedProcesses.__mockProcess(
+				'yarn',
+				['global', 'dir', '--json'],
+				['{"type":"log","data":"/path/to/yarn/global/dir"}'],
+			);
+
+			mockedProcesses.__mockProcess(
+				'npm',
+				['config', 'get', 'prefix'],
+				['/path/to/npm/global/dir'],
+			);
+
+			mockedProcesses.__mockProcess('pnpm', ['root', '-g'], ['/path/to/pnpm/global/dir']);
+
+			getGlobalPathResolver = require('../global-path-resolver').getGlobalPathResolver;
+		});
+
+		beforeEach(() => {
+			mockedProcesses.runProcessFindLine.mockClear();
+		});
+
+		it('should cache the yarn global package directory', async () => {
+			const resolver = getGlobalPathResolver();
+			const globalPath = await resolver.resolve('yarn');
+			const globalPath2 = await resolver.resolve('yarn');
+
+			expect(globalPath).toBe(globalPath2);
+			expect(mockedProcesses.runProcessFindLine).toHaveBeenCalledTimes(1);
+		});
+
+		it('should cache the npm global package directory', async () => {
+			const resolver = getGlobalPathResolver();
+			const globalPath = await resolver.resolve('npm');
+			const globalPath2 = await resolver.resolve('npm');
+
+			expect(globalPath).toBe(globalPath2);
+			expect(mockedProcesses.runProcessFindLine).toHaveBeenCalledTimes(1);
+		});
+
+		it('should cache the pnpm global package directory', async () => {
+			const resolver = getGlobalPathResolver();
+			const globalPath = await resolver.resolve('pnpm');
+			const globalPath2 = await resolver.resolve('pnpm');
+
+			expect(globalPath).toBe(globalPath2);
+			expect(mockedProcesses.runProcessFindLine).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('Error handling', () => {
+		describe('Missing commands', () => {
+			/** @type {getGlobalPathResolver} */
+			let getGlobalPathResolver;
+
+			beforeAll(() => {
+				mockPlatform('posix');
+
+				const mockedProcesses = /** @type {tests.mocks.Processes} */ (require('../../processes'));
+
+				mockedProcesses.__resetMockedProcesses();
+
+				getGlobalPathResolver = require('../global-path-resolver').getGlobalPathResolver;
+			});
+
+			it('should throw an error if yarn cannot be found', async () => {
+				const resolver = getGlobalPathResolver();
+
+				await expect(resolver.resolve('yarn')).rejects.toThrowErrorMatchingSnapshot();
+			});
+
+			it('should throw an error if npm cannot be found', async () => {
+				const resolver = getGlobalPathResolver();
+
+				await expect(resolver.resolve('npm')).rejects.toThrowErrorMatchingSnapshot();
+			});
+
+			it('should throw an error if pnpm cannot be found', async () => {
+				const resolver = getGlobalPathResolver();
+
+				await expect(resolver.resolve('pnpm')).rejects.toThrowErrorMatchingSnapshot();
+			});
+		});
+
+		describe('Bad output', () => {
+			/** @type {getGlobalPathResolver} */
+			let getGlobalPathResolver;
+
+			/** @type {tests.mocks.Processes} */
+			let mockedProcesses;
+
+			beforeAll(() => {
+				mockPlatform('posix');
+
+				mockedProcesses = /** @type {tests.mocks.Processes} */ (require('../../processes'));
+
+				mockedProcesses.__resetMockedProcesses();
+
+				mockedProcesses.__mockProcess('npm', ['config', 'get', 'prefix'], ['']);
+
+				mockedProcesses.__mockProcess('pnpm', ['root', '-g'], ['']);
+
+				getGlobalPathResolver = require('../global-path-resolver').getGlobalPathResolver;
+			});
+
+			it('should resolve to undefined for yarn', async () => {
+				mockedProcesses.__mockProcess('yarn', ['global', 'dir', '--json'], ['{badjson']);
+				let globalPath = await getGlobalPathResolver().resolve('yarn');
+
+				expect(globalPath).toBeUndefined();
+
+				mockedProcesses.__mockProcess('yarn', ['global', 'dir', '--json'], ['{"type":"notlog"}']);
+				globalPath = await getGlobalPathResolver().resolve('yarn');
+
+				expect(globalPath).toBeUndefined();
+
+				mockedProcesses.__mockProcess('yarn', ['global', 'dir', '--json'], ['']);
+				globalPath = await getGlobalPathResolver().resolve('yarn');
+
+				expect(globalPath).toBeUndefined();
+			});
+
+			it('should resolve to undefined for npm', async () => {
+				const resolver = getGlobalPathResolver();
+				const globalPath = await resolver.resolve('npm');
+
+				expect(globalPath).toBeUndefined();
+			});
+
+			it('should resolve to undefined for pnpm', async () => {
+				const resolver = getGlobalPathResolver();
+				const globalPath = await resolver.resolve('pnpm');
+
+				expect(globalPath).toBeUndefined();
+			});
+		});
+
+		describe('Non-zero exit codes', () => {
+			/** @type {getGlobalPathResolver} */
+			let getGlobalPathResolver;
+
+			beforeAll(() => {
+				const mockedOS = /** @type {tests.mocks.OSModule} */ (require('os'));
+
+				mockedOS.__mockPlatform('linux');
+
+				const mockedPath = /** @type {tests.mocks.PathModule} */ (require('path'));
+
+				mockedPath.__mockPlatform('posix');
+
+				const mockedProcesses = /** @type {tests.mocks.Processes} */ (require('../../processes'));
+
+				mockedProcesses.__resetMockedProcesses();
+
+				mockedProcesses.__mockProcess(
+					'yarn',
+					['global', 'dir', '--json'],
+					['{"type":"log","data":"/path/to/yarn/global/dir"}'],
+					1,
+				);
+
+				mockedProcesses.__mockProcess(
+					'npm',
+					['config', 'get', 'prefix'],
+					['/path/to/npm/global/dir'],
+					1,
+				);
+
+				mockedProcesses.__mockProcess('pnpm', ['root', '-g'], ['/path/to/pnpm/global/dir'], 1);
+
+				getGlobalPathResolver = require('../global-path-resolver').getGlobalPathResolver;
+			});
+
+			it('should throw an error if yarn returns a non-zero exit code', async () => {
+				const resolver = getGlobalPathResolver();
+
+				await expect(resolver.resolve('yarn')).rejects.toThrowErrorMatchingSnapshot();
+			});
+
+			it('should throw an error if npm returns a non-zero exit code', async () => {
+				const resolver = getGlobalPathResolver();
+
+				await expect(resolver.resolve('npm')).rejects.toThrowErrorMatchingSnapshot();
+			});
+
+			it('should throw an error if pnpm returns a non-zero exit code', async () => {
+				const resolver = getGlobalPathResolver();
+
+				await expect(resolver.resolve('pnpm')).rejects.toThrowErrorMatchingSnapshot();
+			});
+		});
+
+		describe('Unsupported package managers', () => {
+			it('should resolve to undefined when passed an unsupported package manager name', async () => {
+				const getGlobalPathResolver = require('../global-path-resolver').getGlobalPathResolver;
+
+				const globalPath = await getGlobalPathResolver().resolve(
+					/** @type {any} */ ('unsupported'),
+				);
+
+				expect(globalPath).toBeUndefined();
+			});
+		});
+	});
+});

--- a/src/utils/packages/global-path-resolver.js
+++ b/src/utils/packages/global-path-resolver.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const { runProcessFindLine } = require('../processes');
+
+/** @type {{[key in PackageManager]: (trace?: TracerFn, isWindows?: boolean) => Promise<string | undefined>}} */
+const resolvers = {
+	/**
+	 * Resolves the global `node_modules` path for Yarn.
+	 *
+	 * Note: Only Yarn 1.x is supported. Yarn 2.x and higher have removed
+	 * support for globally installed packages.
+	 */
+	async yarn(trace, isWindows) {
+		const tryTrace = trace ?? (() => undefined);
+		/** @param {string} line */
+		const tryParseLog = (line) => {
+			/** @type {{type: any, data: any}} */
+			let log;
+
+			try {
+				log = JSON.parse(line);
+			} catch {
+				return undefined;
+			}
+
+			return log;
+		};
+
+		const yarnGlobalPath = await runProcessFindLine(
+			'yarn',
+			['global', 'dir', '--json'],
+			isWindows ? { shell: true } : undefined,
+			(line) => {
+				const log = tryParseLog(line);
+
+				if (!log || log.type !== 'log' || !log.data) {
+					return undefined;
+				}
+
+				const globalPath = path.join(log.data, 'node_modules');
+
+				tryTrace(`Yarn returned global path: "${globalPath}"`);
+
+				return globalPath;
+			},
+		);
+
+		if (!yarnGlobalPath) {
+			tryTrace('"yarn global dir --json" did not return a path.');
+
+			return undefined;
+		}
+
+		return yarnGlobalPath;
+	},
+
+	/**
+	 * Resolves the global `node_modules` path for npm.
+	 */
+	async npm(trace, isWindows) {
+		const tryTrace = trace ?? (() => undefined);
+		const npmGlobalPath = await runProcessFindLine(
+			'npm',
+			['config', 'get', 'prefix'],
+			isWindows ? { shell: true } : undefined,
+			(line) => {
+				const trimmed = line.trim();
+
+				if (!trimmed) {
+					return undefined;
+				}
+
+				const globalPath =
+					os.platform() === 'win32'
+						? path.join(trimmed, 'node_modules')
+						: path.join(trimmed, 'lib/node_modules');
+
+				tryTrace(`npm returned global path: "${globalPath}"`);
+
+				return globalPath;
+			},
+		);
+
+		if (!npmGlobalPath) {
+			tryTrace('"npm config get prefix" did not return a path.');
+
+			return undefined;
+		}
+
+		return npmGlobalPath;
+	},
+
+	/**
+	 * Resolves the global `node_modules` path for pnpm.
+	 */
+	async pnpm(trace, isWindows) {
+		const tryTrace = trace ?? (() => undefined);
+		const pnpmGlobalPath = await runProcessFindLine(
+			'pnpm',
+			['root', '-g'],
+			isWindows ? { shell: true } : undefined,
+			(line) => {
+				const trimmed = line.trim();
+
+				if (!trimmed) {
+					return undefined;
+				}
+
+				tryTrace(`pnpm returned global path: "${trimmed}"`);
+
+				return trimmed;
+			},
+		);
+
+		if (!pnpmGlobalPath) {
+			tryTrace('"pnpm root -g" did not return a path.');
+
+			return undefined;
+		}
+
+		return pnpmGlobalPath;
+	},
+};
+
+/**
+ * Returns an object with a `resolve` method that takes as its first parameter
+ * a supported package manager (`npm`, `yarn`, or `pnpm`) and as its second an
+ * optional tracer function that will be used to trace the resolution process.
+ *
+ * On a successful resolution, the method returns a promise that resolves to the
+ * package manager's global `node_modules` path. Paths are cached in the
+ * resolver on the first successful resolution.
+ *
+ * When a path cannot be resolved, the promise resolves to `undefined`.
+ *
+ * @example
+ * ```js
+ * const resolver = getGlobalPathResolver();
+ * const yarnGlobalPath = await resolver.resolve(
+ *   'yarn',
+ *   message => connection && connection.tracer.log(message)
+ * );
+ * ```
+ * @returns {GlobalPathResolver}
+ */
+function getGlobalPathResolver() {
+	/** @type {GlobalPathResolverCache} */
+	const cache = {};
+
+	return {
+		async resolve(packageManager, trace) {
+			const cached = cache[packageManager];
+
+			if (cached) {
+				return cached;
+			}
+
+			const tryTrace = trace ?? (() => undefined);
+			const resolver = resolvers[packageManager];
+
+			if (!resolver) {
+				tryTrace(`Package manager "${packageManager}" is not supported.`);
+
+				return undefined;
+			}
+
+			const isWindows = os.platform() === 'win32';
+			const globalPath = await resolver(trace, isWindows);
+
+			if (globalPath) {
+				cache[packageManager] = globalPath;
+			}
+
+			return globalPath;
+		},
+	};
+}
+
+module.exports = {
+	getGlobalPathResolver,
+};

--- a/src/utils/packages/index.js
+++ b/src/utils/packages/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+	...require('./global-path-resolver'),
+	...require('./find-package-root'),
+};

--- a/src/utils/processes.js
+++ b/src/utils/processes.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const cp = require('child_process');
+const readline = require('readline');
+
+/**
+ * Runs a process and returns the output as read by the given matcher. The
+ * matcher is called for each line of the output with the line. The promise
+ * returned by this function is resolved to the first value returned by the
+ * matcher once the process has exited.
+ *
+ * If the matcher returns `undefined`, the line is ignored.
+ *
+ * If the matcher never returns a value, the promise is resolved to `undefined`.
+ *
+ * If the matcher throws an error, the promise is rejected with the error and
+ * an attempt is made to kill the process.
+ *
+ * If the process exits with a non-zero exit code or if the child process API
+ * emits an error, the promise is rejected with the exit code or error.
+ * @template T
+ * @param {string} command Shell command or path to executable
+ * @param {string[]} args Arguments to pass to the command
+ * @param {cp.SpawnOptionsWithoutStdio | undefined} options Options to pass to the spawner
+ * @param {(line: string) => (T | undefined)} matcher Function to match the output line
+ * @returns {Promise<T | undefined>}
+ */
+function runProcessFindLine(command, args, options, matcher) {
+	return new Promise((resolve, reject) => {
+		const childProcess = cp.spawn(command, args, options);
+
+		const stdoutReader = readline.createInterface({
+			input: childProcess.stdout,
+		});
+
+		/** @type {T | undefined} */
+		let returnValue = undefined;
+
+		/** @type {number | NodeJS.Signals | null | undefined} */
+		let exitCode = undefined;
+		let resolved = false;
+		let streamClosed = false;
+
+		const resolveOrRejectIfNeeded = () => {
+			if (resolved || exitCode === undefined || !streamClosed) {
+				return;
+			}
+
+			resolved = true;
+
+			if (exitCode === 0) {
+				resolve(returnValue);
+			} else {
+				reject(new Error(`Command "${command}" exited with code ${exitCode}.`));
+			}
+		};
+
+		/**
+		 * @param {unknown} error
+		 * @returns {void}
+		 */
+		const handleError = (error) => {
+			resolved = true;
+			childProcess.removeAllListeners();
+			stdoutReader.close();
+
+			try {
+				childProcess.kill();
+			} catch {
+				// ignore
+			}
+
+			reject(error);
+		};
+
+		stdoutReader.on('line', (line) => {
+			if (resolved || returnValue !== undefined) {
+				return;
+			}
+
+			try {
+				const matched = matcher(line);
+
+				if (matched !== undefined) {
+					returnValue = matched;
+				}
+
+				resolveOrRejectIfNeeded();
+			} catch (error) {
+				handleError(error);
+			}
+		});
+
+		stdoutReader.on('close', () => {
+			if (resolved) {
+				return;
+			}
+
+			streamClosed = true;
+			resolveOrRejectIfNeeded();
+		});
+
+		childProcess.on('error', handleError);
+
+		childProcess.on('exit', (code, signal) => {
+			exitCode = code ?? signal;
+
+			resolveOrRejectIfNeeded();
+		});
+	});
+}
+
+module.exports = {
+	runProcessFindLine,
+};

--- a/test/mockSystemErrors.js
+++ b/test/mockSystemErrors.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// Part of test utils, don't record coverage
+/* istanbul ignore file */
+
+const util = require('util');
+
+/**
+ * Mock file system error messages by code.
+ */
+const errorMessages = {
+	ENOENT: "ENOENT: no such file or directory, open '%s'",
+	EACCES: "EACCES: permission denied, open '%s'",
+};
+
+/**
+ * Creates a mock file system error.
+ * @param {keyof typeof errorMessages} code
+ * @param {string} fsPath
+ * @param {number} errno
+ * @param {string} syscall
+ */
+const createError = (code, fsPath, errno, syscall) =>
+	Object.assign(new Error(util.format(errorMessages[code], fsPath)), {
+		code,
+		errno,
+		path: fsPath,
+		syscall,
+	});
+
+module.exports = {
+	createError,
+};

--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -1,0 +1,3 @@
+Unit tests are located in `__tests__` directories in [`src`](../../src) ([example](../../src/utils/__tests__)).
+
+Mocks for Node modules are in the [`__mocks__`](../../__mocks__) directory of the project root, and mocks for local modules are in the `__mocks__` directory at the same level as the module being mocked ([example](../../src/utils/__mocks__)).

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -1,0 +1,11 @@
+'use strict';
+
+/** @type {import('@jest/types').Config.InitialOptions} */
+const config = {
+	rootDir: '../..',
+	testMatch: ['<rootDir>/src/**/__tests__/**/*.[jt]s?(x)'],
+	verbose: true,
+	modulePathIgnorePatterns: ['<rootDir>/.vscode-test'],
+};
+
+module.exports = config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
 		"resolveJsonModule": true,
 		"typeRoots": ["./types", "./node_modules/@types"]
 	},
-	"include": ["src/**/*", "test/**/*", "scripts/**/*", "types/*.d.ts"],
+	"include": ["src/**/*", "test/**/*", "__mocks__/**/*", "scripts/**/*", "types/*.d.ts"],
 	"exclude": ["**/coverage"]
 }


### PR DESCRIPTION
- Replace calls to deprecated `Files.uriToFilePath` with vscode-uri
- Replace calls to deprecated `Files.resolveGlobal...Path` with resolver implementation that uses asynchronous interaction with processes — no more `execSync`
- Broke utils out into separate files under `src/utils`
- Add unit tests to test new code. `lib` tests will be broken out into unit tests in future changes as `stylelint-vscode.js` and `server.js` are refactored to be more testable (see #255)
- 100% statement, branch, function, and line coverage for new code