### PR TITLE
fix: fire onDidChangeValidateLanguages on first config

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-stylelint",
   "version": "1.0.0",
   "license": "MIT",
-  "description": "Modern CSS/SCSS/Less linter",
+  "description": "Modern CSS/Less/SCSS linter",
   "main": "dist/index.js",
   "displayName": "Stylelint",
   "publisher": "stylelint",
@@ -114,6 +114,7 @@
           },
           "default": [
             "css",
+            "less",
             "postcss"
           ],
           "description": "An array of language ids which should be validated by stylelint."
@@ -126,6 +127,7 @@
           },
           "default": [
             "css",
+            "less",
             "postcss"
           ],
           "description": "An array of language ids which snippets are provided by stylelint."

--- a/src/server/__tests__/__snapshots__/server.js.snap
+++ b/src/server/__tests__/__snapshots__/server.js.snap
@@ -208,6 +208,41 @@ Object {
 }
 `;
 
+exports[`StylelintLanguageServer should fire onDidChangeValidateLanguages when first settings are sent to server 1`] = `
+Object {
+  "config": undefined,
+  "configBasedir": undefined,
+  "configFile": undefined,
+  "customSyntax": undefined,
+  "ignoreDisables": undefined,
+  "packageManager": "npm",
+  "reportInvalidScopeDisables": undefined,
+  "reportNeedlessDisables": undefined,
+  "snippet": Array [
+    "css",
+    "less",
+    "postcss",
+  ],
+  "stylelintPath": undefined,
+  "validate": Array [
+    "css",
+    "less",
+    "postcss",
+  ],
+}
+`;
+
+exports[`StylelintLanguageServer should fire onDidChangeValidateLanguages when first settings are sent to server 2`] = `
+Object {
+  "languages": Set {
+    "css",
+    "less",
+    "postcss",
+  },
+  "removedLanguages": Set {},
+}
+`;
+
 exports[`StylelintLanguageServer should fire onDidChangeValidateLanguages when validate option changes 1`] = `
 Object {
   "config": undefined,
@@ -257,6 +292,34 @@ Object {
   "configFile": undefined,
   "customSyntax": undefined,
   "ignoreDisables": undefined,
+  "packageManager": "npm",
+  "reportInvalidScopeDisables": undefined,
+  "reportNeedlessDisables": undefined,
+  "snippet": Array [
+    "css",
+    "less",
+    "postcss",
+  ],
+  "stylelintPath": undefined,
+  "validate": Array [
+    "css",
+    "less",
+    "postcss",
+  ],
+}
+`;
+
+exports[`StylelintLanguageServer should receive updates to settings from the client and pass them to modules 1`] = `
+Object {
+  "config": Object {
+    "rules": Object {
+      "block-no-empty": true,
+    },
+  },
+  "configBasedir": undefined,
+  "configFile": undefined,
+  "customSyntax": undefined,
+  "ignoreDisables": true,
   "packageManager": "npm",
   "reportInvalidScopeDisables": undefined,
   "reportNeedlessDisables": undefined,

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -70,6 +70,12 @@ class StylelintLanguageServer {
 	#modules = new Map();
 
 	/**
+	 * Whether or not the server has sent its first configuration change to
+	 * modules.
+	 */
+	#hasSentInitialConfiguration = false;
+
+	/**
 	 * Creates a new Stylelint language server.
 	 * @param {LanguageServerConstructorParameters} params
 	 */
@@ -376,7 +382,7 @@ class StylelintLanguageServer {
 			}
 		}
 
-		if (changed) {
+		if (changed || !this.#hasSentInitialConfiguration) {
 			if (this.#logger?.isDebugEnabled()) {
 				this.#logger?.debug('Languages that should be validated changed', {
 					languages: [...validateLanguageSet],
@@ -391,6 +397,8 @@ class StylelintLanguageServer {
 		}
 
 		this.#invokeHandlers('onDidChangeConfiguration', { settings: this.#options });
+
+		this.#hasSentInitialConfiguration = true;
 	}
 }
 


### PR DESCRIPTION
Fixes #268

- When the server receives its first configuration request from the client, fires `onDidChangeValidateLanguages` to make sure all modules are notified of defaults.
- Adds Less to the extension manifest defaults, from which it was missing.
- Unit tests added.