### PR TITLE
fix: don't validate Less by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [Less](https://lesscss.org/) is no longer linted by default. It was added as a default due to an oversight in the previous release. Only documents with language identifiers `css` and `postcss` will be linted by default. ([#280](https://github.com/stylelint/vscode-stylelint/pull/280))
+
 ## [1.0.1](https://github.com/stylelint/vscode-stylelint/compare/v1.0.0...v1.0.1) (2021-10-22)
 
 ### Fixed
 
-- [Less](https://lesscss.org/) is now correctly linted by default ([#270](https://github.com/stylelint/vscode-stylelint/pull/270)).
+- ~~[Less](https://lesscss.org/) is now correctly linted by default ([#270](https://github.com/stylelint/vscode-stylelint/pull/270)).~~
 
 ## [1.0.0](https://github.com/stylelint/vscode-stylelint/compare/v0.87.6...v1.0.0) (2021-10-21)
 
@@ -16,8 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Dropped support for Stylelint 13 and prior; only Stylelint 14 is supported now. See the [migration guide](README.md#%EF%B8%8F-stylelint-13x-and-prior-is-no-longer-supported) for more details.
 - Removed bundled copy of Stylelint; local or global installation is now required. See the [migration guide](README.md#%EF%B8%8F-stylelint-is-no-longer-bundled) for more details.
-- Validation and completion now only works for documents with language identifiers `css`, `less`, and `postcss` by default. See the [migration guide](README.md#%EF%B8%8F-only-css-less-and-postcss-are-validated-by-default) for more details.
-- `stylelint.syntax` configuration option removed; use `stylelint.customSyntax` instead. See the [migration guide](README.md#%EF%B8%8F-only-css-less-and-postcss-are-validated-by-default) for more details.
+- Validation and completion now only works for documents with language identifiers `css` and `postcss` by default. See the [migration guide](README.md#%EF%B8%8F-only-css-and-postcss-are-validated-by-default) for more details.
+- `stylelint.syntax` configuration option removed; use `stylelint.customSyntax` instead. See the [migration guide](README.md#%EF%B8%8F-only-css-and-postcss-are-validated-by-default) for more details.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For example, the following entries in `.vscode/settings.json` would disable the 
 
 > See the [Stylelint getting started guide] for more information.
 
-Once you create a [Stylelint configuration file] or configure [the Stylelint extension's settings](#extension-settings), Stylelint will automatically validate CSS, [Less], and [PostCSS][postcss extension] documents (those with [language identifiers] `css`, `less`, `postcss`, respectively).
+Once you create a [Stylelint configuration file] or configure [the Stylelint extension's settings](#extension-settings), Stylelint will automatically validate CSS and [PostCSS][postcss extension] documents (those with [language identifiers] `css` and `postcss`, respectively).
 
 <img width="430" alt="Screenshot of UI to select a language identifier" src="https://raw.githubusercontent.com/stylelint/vscode-stylelint/main/media/language.png">
 
@@ -52,7 +52,7 @@ _You can see or change the current document's language in the bottom-right corne
 
 vscode-stylelint 1.x expects to use Stylelint 14 at minimum. Usage with prior versions of Stylelint is not supported nor recommended. If you want to continue using this extension, upgrade your copy of Stylelint to version 14 or later.
 
-The `syntax` and `configOverrides` options have been removed from Stylelint 14 and this extension. See the [following section](#%EF%B8%8F-only-css-less-and-postcss-are-validated-by-default) for information on how to use different syntaxes.
+The `syntax` and `configOverrides` options have been removed from Stylelint 14 and this extension. See the [following section](#%EF%B8%8F-only-css-and-postcss-are-validated-by-default) for information on how to use different syntaxes.
 
 ### ⚠️ Stylelint is No Longer Bundled
 
@@ -60,11 +60,11 @@ Unlike 0.x, 1.x no longer provides a copy of Stylelint bundled with the extensio
 
 Starting with 1.x, vscode-stylelint will depend on having a copy of Stylelint installed in the open workspace (recommended) or globally (not recommended). If the extension doesn't seem to be linting any documents, make sure you have Stylelint installed.
 
-### ⚠️ Only CSS, Less, and PostCSS are Validated by Default
+### ⚠️ Only CSS and PostCSS are Validated by Default
 
 The 0.x versions of this extension, which used Stylelint 13.x and prior, supported validating many different languages out of the box without any additional configuration. However, this added a lot of complexity and resulted in many cases of unwanted or unexpected behaviour.
 
-In current versions of the extension, the extension only supports validating CSS, Less, and PostCSS out of the box and requires additional configuration to validate other languages. You will need to:
+In current versions of the extension, the extension only supports validating CSS and PostCSS out of the box and requires additional configuration to validate other languages. You will need to:
 
 1. Install the PostCSS syntax for the language you want to validate into your workspace, e.g. [postcss-scss].
 1. Configure Stylelint to use the syntax by providing the module name in the [`customSyntax`] option using overrides (or use the [corresponding option](#stylelintcustomsyntax) in this extension's settings).
@@ -169,7 +169,7 @@ Sets the Stylelint [`reportInvalidScopeDisables`] option. If `true`, Stylelint r
 ### `stylelint.validate`
 
 > Type: `string[]`  
-> Default: `["css", "less", "postcss"]`
+> Default: `["css", "postcss"]`
 
 An array of language identifiers specifying which files to validate.
 
@@ -190,7 +190,7 @@ Controls the package manager to be used to resolve the Stylelint library. This s
 ### `stylelint.snippet`
 
 > Type: `string[]`  
-> Default: `["css", "less", "postcss"]`
+> Default: `["css", "postcss"]`
 
 An array of language identifiers specifying which files to enable snippets for.
 
@@ -247,7 +247,6 @@ This extension contributes the following commands to the command palette:
 
 [css]: https://www.w3.org/Style/CSS/
 [scss]: https://sass-lang.com/documentation/syntax
-[less]: http://lesscss.org/
 
 <!-- PostCSS -->
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "stylelint.enable": {
           "type": "boolean",
           "default": true,
-          "description": "Control whether Stylelint is enabled for CSS/SCSS/Less files or not."
+          "description": "Control whether Stylelint is enabled or not."
         },
         "stylelint.config": {
           "type": [

--- a/src/server/__tests__/__snapshots__/server.js.snap
+++ b/src/server/__tests__/__snapshots__/server.js.snap
@@ -25,12 +25,10 @@ Object {
       "packageManager": "npm",
       "snippet": Array [
         "css",
-        "less",
         "postcss",
       ],
       "validate": Array [
         "css",
-        "less",
         "postcss",
       ],
     },
@@ -112,12 +110,10 @@ Array [
       "packageManager": "npm",
       "snippet": Array [
         "css",
-        "less",
         "postcss",
       ],
       "validate": Array [
         "css",
-        "less",
         "postcss",
       ],
     },
@@ -132,12 +128,10 @@ Array [
       "packageManager": "npm",
       "snippet": Array [
         "css",
-        "less",
         "postcss",
       ],
       "validate": Array [
         "css",
-        "less",
         "postcss",
       ],
     },
@@ -158,12 +152,10 @@ Array [
       "packageManager": "npm",
       "snippet": Array [
         "css",
-        "less",
         "postcss",
       ],
       "validate": Array [
         "css",
-        "less",
         "postcss",
       ],
     },
@@ -177,12 +169,10 @@ Array [
       "packageManager": "npm",
       "snippet": Array [
         "css",
-        "less",
         "postcss",
       ],
       "validate": Array [
         "css",
-        "less",
         "postcss",
       ],
     },
@@ -220,13 +210,11 @@ Object {
   "reportNeedlessDisables": undefined,
   "snippet": Array [
     "css",
-    "less",
     "postcss",
   ],
   "stylelintPath": undefined,
   "validate": Array [
     "css",
-    "less",
     "postcss",
   ],
 }
@@ -236,7 +224,6 @@ exports[`StylelintLanguageServer should fire onDidChangeValidateLanguages when f
 Object {
   "languages": Set {
     "css",
-    "less",
     "postcss",
   },
   "removedLanguages": Set {},
@@ -255,7 +242,6 @@ Object {
   "reportNeedlessDisables": undefined,
   "snippet": Array [
     "css",
-    "less",
     "postcss",
   ],
   "stylelintPath": undefined,
@@ -271,7 +257,6 @@ Object {
     "css",
   },
   "removedLanguages": Set {
-    "less",
     "postcss",
   },
 }
@@ -297,13 +282,11 @@ Object {
   "reportNeedlessDisables": undefined,
   "snippet": Array [
     "css",
-    "less",
     "postcss",
   ],
   "stylelintPath": undefined,
   "validate": Array [
     "css",
-    "less",
     "postcss",
   ],
 }
@@ -325,13 +308,11 @@ Object {
   "reportNeedlessDisables": undefined,
   "snippet": Array [
     "css",
-    "less",
     "postcss",
   ],
   "stylelintPath": undefined,
   "validate": Array [
     "css",
-    "less",
     "postcss",
   ],
 }

--- a/src/server/__tests__/server.js
+++ b/src/server/__tests__/server.js
@@ -546,7 +546,7 @@ describe('StylelintLanguageServer', () => {
 
 		expect(mockLogger.debug).toHaveBeenCalledWith('Languages that should be validated changed', {
 			languages: ['css'],
-			removedLanguages: ['less', 'postcss'],
+			removedLanguages: ['postcss'],
 		});
 	});
 
@@ -574,7 +574,7 @@ describe('StylelintLanguageServer', () => {
 			'Languages that should be validated changed',
 			{
 				languages: ['css'],
-				removedLanguages: ['less', 'postcss'],
+				removedLanguages: ['postcss'],
 			},
 		);
 	});

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -13,8 +13,8 @@ const { StylelintResolver } = require('../utils/packages');
 /** @type {LanguageServerOptions} */
 const defaultOptions = {
 	packageManager: 'npm',
-	validate: ['css', 'less', 'postcss'],
-	snippet: ['css', 'less', 'postcss'],
+	validate: ['css', 'postcss'],
+	snippet: ['css', 'postcss'],
 };
 
 /**


### PR DESCRIPTION
See https://github.com/stylelint/vscode-stylelint/issues/268#issuecomment-951177099

- Removed Less from extension defaults.
- Removed Less from language server defaults.
- Removed Less from snapshots/tests where appropriate.
- Updated readme and change log.