### PR TITLE
refactor: Check `this.#logger` separately

### DIFF
--- a/src/utils/packages/stylelint-resolver.js
+++ b/src/utils/packages/stylelint-resolver.js
@@ -43,15 +43,17 @@ class StylelintResolver {
 	/**
 	 * Logs an error message through the connection if one is available.
 	 * @param {string} message The message to log.
+	 * @param {unknown} [error] The error to log.
 	 * @returns {void}
 	 */
-	#logError(message) {
-		if (!this.#connection) {
-			return;
+	#logError(message, error) {
+		if (this.#logger) {
+			this.#logger?.error(message, error && { error });
 		}
 
-		this.#connection.window.showErrorMessage(`Stylelint: ${message}`);
-		this.#logger?.error(message);
+		if (this.#connection) {
+			this.#connection.window.showErrorMessage(`Stylelint: ${message}`);
+		}
 	}
 
 	/**
@@ -99,7 +101,7 @@ class StylelintResolver {
 				};
 			}
 		} catch (err) {
-			this.#logError(errorMessage);
+			this.#logError(errorMessage, err);
 
 			throw err;
 		}
@@ -127,12 +129,10 @@ class StylelintResolver {
 		const connection = this.#connection;
 
 		/** @type {TracerFn} */
-		const trace = connection
-			? (message, verbose) => {
-					this.#logger?.debug(message, { verbose });
-					connection.tracer.log(message, verbose);
-			  }
-			: () => undefined;
+		const trace = (message, verbose) => {
+			this.#logger?.debug(message, { verbose });
+			connection?.tracer.log(message, verbose);
+		};
 
 		try {
 			/** @type {string | undefined} */
@@ -194,9 +194,8 @@ class StylelintResolver {
 		);
 
 		const stylelint = await getFirstResolvedValue(
-			async () => this.#resolveFromPath(stylelintPath, getWorkspaceFolderFn),
-			async () =>
-				await this.#resolveFromModules(textDocument, getWorkspaceFolderFn, packageManager),
+			() => this.#resolveFromPath(stylelintPath, getWorkspaceFolderFn),
+			() => this.#resolveFromModules(textDocument, getWorkspaceFolderFn, packageManager),
 		);
 
 		if (!stylelint) {


### PR DESCRIPTION
Don't assume `#logger` isn't available when `#connection` isn't.

See https://github.com/stylelint/vscode-stylelint/issues/281#issuecomment-953650843 for context