### PR TITLE
fix: properly serialize errors sent to logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "fast-diff": "^1.2.0",
         "path-is-inside": "^1.0.2",
         "semver": "^7.3.5",
+        "serialize-error": "^8.1.0",
         "triple-beam": "^1.3.0",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver": "^7.0.0",
@@ -10277,6 +10278,31 @@
         "node": ">=10"
       }
     },
+    "node_modules/serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -19371,6 +19397,21 @@
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "requires": {
         "lru-cache": "^6.0.0"
+      }
+    },
+    "serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "requires": {
+        "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+        }
       }
     },
     "setimmediate": {

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "fast-diff": "^1.2.0",
     "path-is-inside": "^1.0.2",
     "semver": "^7.3.5",
+    "serialize-error": "^8.1.0",
     "triple-beam": "^1.3.0",
     "vscode-languageclient": "^7.0.0",
     "vscode-languageserver": "^7.0.0",

--- a/src/start-server.js
+++ b/src/start-server.js
@@ -6,7 +6,11 @@ const { StylelintLanguageServer, modules } = require('./server');
 
 const connection = createConnection(ProposedFeatures.all);
 
-const { LanguageServerTransport, LanguageServerFormatter } = require('./utils/logging');
+const {
+	ErrorFormatter,
+	LanguageServerTransport,
+	LanguageServerFormatter,
+} = require('./utils/logging');
 
 const { NODE_ENV } = process.env;
 
@@ -16,10 +20,13 @@ const level = NODE_ENV === 'development' ? 'debug' : 'info';
 const transports = [
 	new LanguageServerTransport({
 		connection,
-		format: new LanguageServerFormatter({
-			connection,
-			preferredKeyOrder: ['module', 'uri', 'command'],
-		}),
+		format: winston.format.combine(
+			new ErrorFormatter(),
+			new LanguageServerFormatter({
+				connection,
+				preferredKeyOrder: ['module', 'uri', 'command'],
+			}),
+		),
 	}),
 ];
 
@@ -28,7 +35,11 @@ if (level === 'debug') {
 		new winston.transports.File({
 			filename: require('path').join(__dirname, '../stylelint-language-server.log'),
 			level,
-			format: winston.format.combine(winston.format.timestamp(), winston.format.json()),
+			format: winston.format.combine(
+				new ErrorFormatter(),
+				winston.format.timestamp(),
+				winston.format.json(),
+			),
 		}),
 	);
 }

--- a/src/utils/__tests__/errors.js
+++ b/src/utils/__tests__/errors.js
@@ -1,0 +1,197 @@
+'use strict';
+
+const { serializeErrors } = require('../errors');
+
+describe('serializeErrors', () => {
+	it('should serialize objects with errors', () => {
+		const error = Object.assign(new Error('error'), { code: 'code' });
+
+		const result = serializeErrors({ error, property: 'value' });
+
+		expect(result).toStrictEqual({
+			error: {
+				name: 'Error',
+				message: 'error',
+				stack: expect.any(String),
+				code: 'code',
+			},
+			property: 'value',
+		});
+	});
+
+	it('should serialize errors', () => {
+		const error = Object.assign(new Error('error'), { code: 'code' });
+
+		const result = serializeErrors(error);
+
+		expect(result).toStrictEqual({
+			name: 'Error',
+			message: 'error',
+			stack: expect.any(String),
+			code: 'code',
+		});
+	});
+
+	it('should serialize errors with nested errors', () => {
+		const error = Object.assign(new Error('error'), { nested: new Error('nested error') });
+
+		const result = serializeErrors(error);
+
+		expect(result).toStrictEqual({
+			name: 'Error',
+			message: 'error',
+			stack: expect.any(String),
+			nested: {
+				name: 'Error',
+				message: 'nested error',
+				stack: expect.any(String),
+			},
+		});
+	});
+
+	it('should serialize arrays with errors', () => {
+		const errors = [new Error('error 1'), Object.assign(new Error('error 2'), { code: 'code 2' })];
+
+		const result = serializeErrors(errors);
+
+		expect(result).toStrictEqual([
+			{
+				message: 'error 1',
+				name: 'Error',
+				stack: expect.any(String),
+			},
+			{
+				message: 'error 2',
+				name: 'Error',
+				code: 'code 2',
+				stack: expect.any(String),
+			},
+		]);
+	});
+
+	it('should serialize maps with errors', () => {
+		const errors = new Map(
+			/** @type {[Error | string, Error | string][]} */ ([
+				['key 1', new Error('error 1')],
+				[new Error('error 2'), 'value 2'],
+			]),
+		);
+
+		const result = serializeErrors(errors);
+
+		expect(result).toStrictEqual(
+			new Map(
+				/** @type {[Object | string, Object | string][]} */ ([
+					[
+						'key 1',
+						{
+							message: 'error 1',
+							name: 'Error',
+							stack: expect.any(String),
+						},
+					],
+					[
+						{
+							message: 'error 2',
+							name: 'Error',
+							stack: expect.any(String),
+						},
+						'value 2',
+					],
+				]),
+			),
+		);
+	});
+
+	it('should serialize sets with errors', () => {
+		const errors = new Set(/** @type {(Error | string)[]} */ ([new Error('error 1'), 'error 2']));
+
+		const result = serializeErrors(errors);
+
+		expect(result).toStrictEqual(
+			new Set(
+				/** @type {(Object | string)[]} */ ([
+					{
+						message: 'error 1',
+						name: 'Error',
+						stack: expect.any(String),
+					},
+					'error 2',
+				]),
+			),
+		);
+	});
+
+	it('should serialize iterables with errors', () => {
+		const errors = [new Error('error 1'), Object.assign(new Error('error 2'), { code: 'code 2' })];
+
+		const result = serializeErrors(errors[Symbol.iterator]());
+
+		expect(result).toStrictEqual([
+			{
+				message: 'error 1',
+				name: 'Error',
+				stack: expect.any(String),
+			},
+			{
+				message: 'error 2',
+				name: 'Error',
+				code: 'code 2',
+				stack: expect.any(String),
+			},
+		]);
+	});
+
+	it('should serialize objects with circular references', () => {
+		const error = Object.assign(new Error('error'), { code: 'code' });
+
+		/**
+		 * @typedef {{error: Error & {code: 'code'}}} TestObject
+		 * @typedef {TestObject & {
+		 *   circular: CircularReferenceObject;
+		 *   circularArray: CircularReferenceObject[];
+		 * }} CircularReferenceObject
+		 */
+
+		const obj = /** @type {CircularReferenceObject} */ ({ error });
+
+		obj.circular = obj;
+		obj.circularArray = [obj];
+
+		const result = serializeErrors(obj);
+
+		expect(result).toStrictEqual({
+			error: {
+				name: 'Error',
+				message: 'error',
+				stack: expect.any(String),
+				code: 'code',
+			},
+			circular: '[Circular]',
+			circularArray: ['[Circular]'],
+		});
+	});
+
+	it('should not modify non-error objects', () => {
+		// Create object with non-enumerable property
+		const obj = Object.create(null);
+
+		Object.defineProperty(obj, 'prop', {
+			value: 'value',
+			enumerable: false,
+		});
+
+		const result = serializeErrors(obj);
+
+		expect(result).toStrictEqual({});
+	});
+
+	it('should not modify non-object values', () => {
+		expect(serializeErrors(null)).toBeNull();
+		expect(serializeErrors(undefined)).toBeUndefined();
+		expect(serializeErrors(true)).toBe(true);
+		expect(serializeErrors(0)).toBe(0);
+		expect(serializeErrors('')).toBe('');
+		expect(serializeErrors('string')).toBe('string');
+	});
+});

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const { serializeError } = require('serialize-error');
+const { isIterable } = require('./iterables');
+
+/**
+ * Takes an object with errors, returning a new object in which each error has
+ * been replaced by a serializable object with the error's properties. Iterables
+ * that aren't arrays, maps, or sets are converted to arrays.
+ * @template T
+ * @template {{[K in keyof T]: T[K]}} R
+ * @param {T} object The object with errors.
+ * @returns {R} The object with each error replaced by a serializable object.
+ */
+function serializeErrors(object) {
+	/**
+	 * @template TInner
+	 * @template {{[KInner in keyof TInner]: TInner[KInner]}} RInner
+	 * @param {TInner} obj The object with errors.
+	 * @param {WeakMap<any, any>} visited The set of objects that have already been visited.
+	 * @returns {RInner} The object with each error replaced by a serializable object.
+	 */
+	const serializeInner = (obj, visited) => {
+		if (!obj || typeof obj !== 'object') {
+			return /** @type {RInner} */ (obj);
+		}
+
+		if (visited.has(obj)) {
+			return visited.get(obj);
+		}
+
+		if (obj instanceof Error) {
+			const result = /** @type {RInner} */ (/** @type {unknown} */ (serializeError(obj)));
+
+			visited.set(obj, result);
+
+			return result;
+		}
+
+		if (obj instanceof Map) {
+			const result = new Map();
+
+			visited.set(obj, result);
+
+			for (const [key, value] of /** @type {Map<any, any>} */ (/** @type {unknown} */ (obj))) {
+				const serializedKey = serializeInner(key, visited);
+				const serializedValue = serializeInner(value, visited);
+
+				if (key && typeof key === 'object') {
+					visited.set(key, serializedKey);
+				}
+
+				if (value && typeof value === 'object') {
+					visited.set(value, serializedValue);
+				}
+
+				result.set(serializedKey, serializedValue);
+			}
+
+			return /** @type {RInner} */ (/** @type {unknown} */ (result));
+		}
+
+		if (obj instanceof Set) {
+			const result = new Set();
+
+			visited.set(obj, result);
+
+			for (const value of /** @type {Set<any>} */ (/** @type {unknown} */ (obj))) {
+				if (!value || typeof value !== 'object') {
+					result.add(value);
+					continue;
+				}
+
+				const serializedValue = serializeInner(value, visited);
+
+				visited.set(value, serializedValue);
+
+				result.add(serializedValue);
+			}
+
+			return /** @type {RInner} */ (/** @type {unknown} */ (result));
+		}
+
+		if (isIterable(obj)) {
+			/** @type {any[]} */
+			const result = [];
+
+			visited.set(obj, result);
+
+			for (const value of /** @type {Iterable<any>} */ (/** @type {unknown} */ (obj))) {
+				result.push(serializeInner(value, visited));
+			}
+
+			return /** @type {RInner} */ (/** @type {unknown} */ (result));
+		}
+
+		visited.set(obj, '[Circular]');
+
+		const serializedObj = /** @type {RInner} */ (
+			Object.fromEntries(
+				Object.entries(obj).map(([key, value]) => {
+					if (!value || typeof value !== 'object') {
+						return [key, value];
+					}
+
+					if (visited.has(value)) {
+						return [key, visited.get(value)];
+					}
+
+					if (value instanceof Error) {
+						const serialized = serializeError(value);
+
+						visited.set(value, serialized);
+
+						return [key, serialized];
+					}
+
+					const result = serializeInner(value, visited);
+
+					visited.set(value, result);
+
+					return [key, result];
+				}),
+			)
+		);
+
+		visited.set(obj, serializedObj);
+
+		return serializedObj;
+	};
+
+	return serializeInner(object, new WeakMap());
+}
+
+module.exports = {
+	serializeErrors,
+};

--- a/src/utils/logging/__tests__/error-formatter.js
+++ b/src/utils/logging/__tests__/error-formatter.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { LEVEL, MESSAGE } = require('triple-beam');
+
+const { ErrorFormatter } = require('../error-formatter');
+
+/**
+ * @param {string} message
+ * @param {string} level
+ * @param {{[key: string | symbol]: any}} [data]
+ * @returns {winston.Logform.TransformableInfo}
+ */
+const createMockInfo = (message, level, data = {}) => {
+	return /** @type {any} */ ({
+		[MESSAGE]: message,
+		[LEVEL]: level,
+		message,
+		level,
+		...data,
+	});
+};
+
+describe('ErrorFormatter', () => {
+	beforeAll(() => {
+		jest.useFakeTimers();
+	});
+
+	afterAll(() => {
+		jest.useRealTimers();
+	});
+
+	test('should format a log message without data', () => {
+		const info = createMockInfo('test message', 'info');
+		const format = new ErrorFormatter();
+
+		expect(format.transform(info)).toStrictEqual({
+			[MESSAGE]: 'test message',
+			[LEVEL]: 'info',
+			message: 'test message',
+			level: 'info',
+		});
+	});
+
+	test('should format a log message with data', () => {
+		const info = createMockInfo('test message', 'warn', {
+			foo: 'bar',
+			error: new Error('test error'),
+		});
+		const format = new ErrorFormatter();
+
+		expect(format.transform(info)).toStrictEqual({
+			[MESSAGE]: 'test message',
+			[LEVEL]: 'warn',
+			message: 'test message',
+			level: 'warn',
+			foo: 'bar',
+			error: {
+				name: 'Error',
+				message: 'test error',
+				stack: expect.any(String),
+			},
+		});
+	});
+});

--- a/src/utils/logging/error-formatter.js
+++ b/src/utils/logging/error-formatter.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const { serializeErrors } = require('../errors');
+
+/**
+ * Language server formatter for winston.
+ * @type {ErrorFormatterConstructor}
+ */
+class ErrorFormatter {
+	/**
+	 * @param {winston.Logform.TransformableInfo & {[key: string | symbol]: any}} info
+	 * @returns {winston.Logform.TransformableInfo}
+	 */
+	transform(info) {
+		const transformed = serializeErrors({ ...info });
+
+		for (const key of Object.keys(transformed)) {
+			info[key] = transformed[key];
+		}
+
+		return info;
+	}
+}
+
+module.exports = {
+	ErrorFormatter,
+};

--- a/src/utils/logging/index.js
+++ b/src/utils/logging/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+	...require('./error-formatter'),
 	...require('./get-log-function'),
 	...require('./language-server-formatter'),
 	...require('./language-server-transport'),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -394,6 +394,29 @@ type LanguageServerFormatterOptions = {
 };
 
 /**
+ * Error log formatter constructor.
+ */
+type ErrorFormatterConstructor = {
+	new (): ErrorFormatter;
+};
+
+/**
+ * Error log formatter.
+ */
+type ErrorFormatter = winston.Logform.Format & {
+	/**
+	 * Formats a log object.
+	 * @param info The log object to format.
+	 */
+	transform(info: winston.Logform.TransformableInfo): winston.Logform.TransformableInfo;
+
+	/**
+	 * Unused.
+	 */
+	options: undefined;
+};
+
+/**
  * VS Code extension event names.
  */
 interface ExtensionEvents {


### PR DESCRIPTION
Encountered in #281 

Prior to this fix, in certain instances, logged errors would be missing critical information, such as `message` or `stack`.

Example, prior to fix:

```
[Debug - 9:24:33 a.m.] [language-server] Log message | error: {}
```

Example, after fix:

```
[Debug - 9:24:33 a.m.] [language-server] Log message | error: {"name":"Error","message":"…","stack":"…"}
```