### PR TITLE
fix: handle failed global node_modules resolution

### DIFF
--- a/src/utils/packages/__mocks__/global-path-resolver.js
+++ b/src/utils/packages/__mocks__/global-path-resolver.js
@@ -2,16 +2,17 @@
 
 const resolver = jest.createMockFromModule('../global-path-resolver');
 
-/** @type {Partial<{[packageManager in PackageManager]: string | undefined}>} */
+/** @type {Partial<{[packageManager in PackageManager]: string | Error | undefined}>} */
 let mockedPaths = {};
 
 /**
- * Mocks the global path for the given package manager.
+ * Mocks the global path for the given package manager. If an error is provided,
+ * the mock will throw the error when called with the given package manager.
  * @param {PackageManager} packageManager
- * @param {string} [globalPath]
+ * @param {string | Error} [globalPathOrError]
  */
-resolver.__mockPath = (packageManager, globalPath) => {
-	mockedPaths[packageManager] = globalPath;
+resolver.__mockPath = (packageManager, globalPathOrError) => {
+	mockedPaths[packageManager] = globalPathOrError;
 };
 
 /**
@@ -24,7 +25,13 @@ resolver.__resetMockedResolutions = () => {
 resolver.getGlobalPathResolver = jest.fn(() => ({
 	/** @param {PackageManager} packageManager */
 	async resolve(packageManager) {
-		return mockedPaths[packageManager];
+		const mocked = mockedPaths[packageManager];
+
+		if (mocked instanceof Error) {
+			throw mocked;
+		}
+
+		return mocked;
 	},
 }));
 

--- a/src/utils/packages/stylelint-resolver.js
+++ b/src/utils/packages/stylelint-resolver.js
@@ -264,7 +264,11 @@ class StylelintResolver {
 		try {
 			/** @type {string | undefined} */
 			const globalModulesPath = packageManager
-				? await this.#globalPathResolver.resolve(packageManager, trace)
+				? await this.#globalPathResolver.resolve(packageManager, trace).catch((error) => {
+						this.#logger?.warn('Failed to resolve global node_modules path', { error });
+
+						return undefined;
+				  })
 				: undefined;
 
 			const documentURI = URI.parse(textDocument.uri);

--- a/types/tests.d.ts
+++ b/types/tests.d.ts
@@ -69,7 +69,7 @@ declare namespace tests {
 		type GlobalPathResolver = jest.Mocked<
 			typeof import('../src/utils/packages/global-path-resolver')
 		> & {
-			__mockPath: (packageManager: PackageManager, path: string) => void;
+			__mockPath: (packageManager: PackageManager, path?: string | Error) => void;
 			__resetMockedPaths: () => void;
 		};
 


### PR DESCRIPTION
Encountered in #281

Prevents an error when resolving the global node_modules path from failing the entire Stylelint package resolution process.