### PR TITLE
fix: make hovering over problems more reliable

### DIFF
--- a/src/utils/stylelint/__tests__/__snapshots__/process-linter-result.ts.snap
+++ b/src/utils/stylelint/__tests__/__snapshots__/process-linter-result.ts.snap
@@ -11,7 +11,7 @@ Object {
       "message": "unit-no-unknown",
       "range": Object {
         "end": Object {
-          "character": 0,
+          "character": 1,
           "line": 0,
         },
         "start": Object {
@@ -30,7 +30,7 @@ Object {
       "message": "at-rule-no-unknown",
       "range": Object {
         "end": Object {
-          "character": 0,
+          "character": 1,
           "line": 0,
         },
         "start": Object {
@@ -46,7 +46,7 @@ Object {
       "message": "alpha-value-notation",
       "range": Object {
         "end": Object {
-          "character": 0,
+          "character": 1,
           "line": 0,
         },
         "start": Object {
@@ -72,7 +72,7 @@ Object {
       "message": "unit-no-unknown",
       "range": Object {
         "end": Object {
-          "character": 0,
+          "character": 1,
           "line": 0,
         },
         "start": Object {

--- a/src/utils/stylelint/__tests__/__snapshots__/stylelint-runner.ts.snap
+++ b/src/utils/stylelint/__tests__/__snapshots__/stylelint-runner.ts.snap
@@ -30,7 +30,7 @@ Object {
       "message": "Unexpected empty block (block-no-empty)",
       "range": Object {
         "end": Object {
-          "character": 2,
+          "character": 3,
           "line": 0,
         },
         "start": Object {
@@ -53,7 +53,7 @@ Object {
       "message": "Unclosed block (CssSyntaxError)",
       "range": Object {
         "end": Object {
-          "character": 0,
+          "character": 1,
           "line": 0,
         },
         "start": Object {

--- a/src/utils/stylelint/__tests__/__snapshots__/warning-to-diagnostic.ts.snap
+++ b/src/utils/stylelint/__tests__/__snapshots__/warning-to-diagnostic.ts.snap
@@ -9,7 +9,7 @@ Object {
   "message": "Expected \\"#AAA\\" to be \\"#aaa\\" (color-hex-case)",
   "range": Object {
     "end": Object {
-      "character": 11,
+      "character": 12,
       "line": 1,
     },
     "start": Object {
@@ -28,7 +28,7 @@ Object {
   "message": "Expected \\"#AAA\\" to be \\"#aaa\\" (color-hex-case)",
   "range": Object {
     "end": Object {
-      "character": 11,
+      "character": 12,
       "line": 1,
     },
     "start": Object {
@@ -47,7 +47,7 @@ Object {
   "message": "Expected \\"#bbbbbb\\" to be \\"#bbb\\" (color-hex-length)",
   "range": Object {
     "end": Object {
-      "character": 18,
+      "character": 19,
       "line": 2,
     },
     "start": Object {

--- a/src/utils/stylelint/warning-to-diagnostic.ts
+++ b/src/utils/stylelint/warning-to-diagnostic.ts
@@ -45,13 +45,14 @@ export function warningToDiagnostic(
 	warning: stylelint.Warning,
 	rules?: { [name: string]: stylelint.Rule },
 ): Diagnostic {
-	const position = Position.create(warning.line - 1, warning.column - 1);
+	const start = Position.create(warning.line - 1, warning.column - 1);
+	const end = Position.create(warning.line - 1, warning.column);
 
 	const ruleDocUrl =
 		rules?.[warning.rule] && `https://stylelint.io/user-guide/rules/${warning.rule}`;
 
 	const diagnostic = Diagnostic.create(
-		Range.create(position, position),
+		Range.create(start, end),
 		warning.text,
 		DiagnosticSeverity[warning.severity === 'warning' ? 'Warning' : 'Error'],
 		warning.rule,

--- a/test/e2e/__tests__/__snapshots__/config-basedir.ts.snap
+++ b/test/e2e/__tests__/__snapshots__/config-basedir.ts.snap
@@ -10,7 +10,7 @@ Array [
     "message": "Expected \\"#fff\\" to be \\"#FFF\\" (color-hex-case)",
     "range": Object {
       "end": Object {
-        "character": 9,
+        "character": 10,
         "line": 1,
       },
       "start": Object {
@@ -29,7 +29,7 @@ Array [
     "message": "Expected indentation of 8 spaces (indentation)",
     "range": Object {
       "end": Object {
-        "character": 2,
+        "character": 3,
         "line": 1,
       },
       "start": Object {

--- a/test/e2e/__tests__/__snapshots__/config-file.ts.snap
+++ b/test/e2e/__tests__/__snapshots__/config-file.ts.snap
@@ -10,7 +10,7 @@ Array [
     "message": "Unexpected empty block (block-no-empty)",
     "range": Object {
       "end": Object {
-        "character": 2,
+        "character": 3,
         "line": 0,
       },
       "start": Object {

--- a/test/e2e/__tests__/__snapshots__/ignore-disables.ts.snap
+++ b/test/e2e/__tests__/__snapshots__/ignore-disables.ts.snap
@@ -10,7 +10,7 @@ Array [
     "message": "Expected \\"#fff\\" to be \\"#FFF\\" (color-hex-case)",
     "range": Object {
       "end": Object {
-        "character": 9,
+        "character": 10,
         "line": 3,
       },
       "start": Object {
@@ -29,7 +29,7 @@ Array [
     "message": "Expected indentation of 4 spaces (indentation)",
     "range": Object {
       "end": Object {
-        "character": 2,
+        "character": 3,
         "line": 3,
       },
       "start": Object {

--- a/test/e2e/__tests__/__snapshots__/lint.ts.snap
+++ b/test/e2e/__tests__/__snapshots__/lint.ts.snap
@@ -7,7 +7,7 @@ Array [
     "message": "Bar (plugin/foo-bar)",
     "range": Object {
       "end": Object {
-        "character": 5,
+        "character": 6,
         "line": 0,
       },
       "start": Object {
@@ -26,7 +26,7 @@ Array [
     "message": "Unexpected invalid hex color \\"#y3\\" (color-no-invalid-hex)",
     "range": Object {
       "end": Object {
-        "character": 11,
+        "character": 12,
         "line": 6,
       },
       "start": Object {
@@ -45,7 +45,7 @@ Array [
     "message": "Expected indentation of 4 spaces (indentation)",
     "range": Object {
       "end": Object {
-        "character": 2,
+        "character": 3,
         "line": 2,
       },
       "start": Object {
@@ -69,7 +69,7 @@ Array [
     "message": "Expected indentation of 4 spaces (indentation)",
     "range": Object {
       "end": Object {
-        "character": 2,
+        "character": 3,
         "line": 2,
       },
       "start": Object {

--- a/test/e2e/__tests__/__snapshots__/report-invalid-scope-disables.ts.snap
+++ b/test/e2e/__tests__/__snapshots__/report-invalid-scope-disables.ts.snap
@@ -7,7 +7,7 @@ Array [
     "message": "Rule \\"foo\\" isn't enabled",
     "range": Object {
       "end": Object {
-        "character": 0,
+        "character": 1,
         "line": 0,
       },
       "start": Object {
@@ -23,7 +23,7 @@ Array [
     "message": "Rule \\"foo\\" isn't enabled",
     "range": Object {
       "end": Object {
-        "character": 0,
+        "character": 1,
         "line": 2,
       },
       "start": Object {
@@ -39,7 +39,7 @@ Array [
     "message": "Rule \\"foo\\" isn't enabled",
     "range": Object {
       "end": Object {
-        "character": 0,
+        "character": 1,
         "line": 4,
       },
       "start": Object {

--- a/test/e2e/__tests__/__snapshots__/report-needless-disables.ts.snap
+++ b/test/e2e/__tests__/__snapshots__/report-needless-disables.ts.snap
@@ -7,7 +7,7 @@ Array [
     "message": "Needless disable for \\"indentation\\"",
     "range": Object {
       "end": Object {
-        "character": 2,
+        "character": 3,
         "line": 2,
       },
       "start": Object {
@@ -23,7 +23,7 @@ Array [
     "message": "Needless disable for \\"indentation\\"",
     "range": Object {
       "end": Object {
-        "character": 0,
+        "character": 1,
         "line": 6,
       },
       "start": Object {
@@ -39,7 +39,7 @@ Array [
     "message": "Needless disable for \\"indentation\\"",
     "range": Object {
       "end": Object {
-        "character": 16,
+        "character": 17,
         "line": 14,
       },
       "start": Object {
@@ -55,7 +55,7 @@ Array [
     "message": "Needless disable for \\"indentation\\"",
     "range": Object {
       "end": Object {
-        "character": 0,
+        "character": 1,
         "line": 17,
       },
       "start": Object {
@@ -71,7 +71,7 @@ Array [
     "message": "Needless disable for \\"unknown\\"",
     "range": Object {
       "end": Object {
-        "character": 2,
+        "character": 3,
         "line": 2,
       },
       "start": Object {

--- a/test/e2e/__tests__/__snapshots__/stylelint-resolution.ts.snap
+++ b/test/e2e/__tests__/__snapshots__/stylelint-resolution.ts.snap
@@ -7,7 +7,7 @@ Array [
     "message": "Fake result",
     "range": Object {
       "end": Object {
-        "character": 0,
+        "character": 1,
         "line": 0,
       },
       "start": Object {
@@ -28,7 +28,7 @@ Array [
     "message": "Fake result from yarn-pnp",
     "range": Object {
       "end": Object {
-        "character": 0,
+        "character": 1,
         "line": 0,
       },
       "start": Object {
@@ -49,7 +49,7 @@ Array [
     "message": "Fake result from yarn-2-pnp",
     "range": Object {
       "end": Object {
-        "character": 0,
+        "character": 1,
         "line": 0,
       },
       "start": Object {
@@ -70,7 +70,7 @@ Array [
     "message": "Fake result from resolve-local",
     "range": Object {
       "end": Object {
-        "character": 0,
+        "character": 1,
         "line": 0,
       },
       "start": Object {

--- a/test/e2e/__tests__/__snapshots__/validate.ts.snap
+++ b/test/e2e/__tests__/__snapshots__/validate.ts.snap
@@ -10,7 +10,7 @@ Array [
     "message": "Expected indentation of 4 spaces (indentation)",
     "range": Object {
       "end": Object {
-        "character": 2,
+        "character": 3,
         "line": 2,
       },
       "start": Object {

--- a/test/integration/stylelint-vscode/__snapshots__/test.ts.snap
+++ b/test/integration/stylelint-vscode/__snapshots__/test.ts.snap
@@ -10,7 +10,7 @@ Array [
     "message": "Expected single quotes (string-quotes)",
     "range": Object {
       "end": Object {
-        "character": 7,
+        "character": 8,
         "line": 0,
       },
       "start": Object {
@@ -29,7 +29,7 @@ Array [
     "message": "Expected indentation of 0 tabs (indentation)",
     "range": Object {
       "end": Object {
-        "character": 2,
+        "character": 3,
         "line": 0,
       },
       "start": Object {
@@ -50,7 +50,7 @@ Array [
     "message": "Unknown rule this-rule-does-not-exist.",
     "range": Object {
       "end": Object {
-        "character": 0,
+        "character": 1,
         "line": 0,
       },
       "start": Object {
@@ -66,7 +66,7 @@ Array [
     "message": "Unknown rule this-rule-also-does-not-exist.",
     "range": Object {
       "end": Object {
-        "character": 0,
+        "character": 1,
         "line": 0,
       },
       "start": Object {
@@ -87,7 +87,7 @@ Array [
     "message": "Unclosed block (CssSyntaxError)",
     "range": Object {
       "end": Object {
-        "character": 10,
+        "character": 11,
         "line": 0,
       },
       "start": Object {
@@ -108,7 +108,7 @@ Array [
     "message": "Unclosed bracket (CssSyntaxError)",
     "range": Object {
       "end": Object {
-        "character": 12,
+        "character": 13,
         "line": 0,
       },
       "start": Object {
@@ -129,7 +129,7 @@ Array [
     "message": "At-rule without name (CssSyntaxError)",
     "range": Object {
       "end": Object {
-        "character": 0,
+        "character": 1,
         "line": 0,
       },
       "start": Object {
@@ -155,7 +155,7 @@ Array [
     "message": "Unclosed string (CssSyntaxError)",
     "range": Object {
       "end": Object {
-        "character": 9,
+        "character": 10,
         "line": 0,
       },
       "start": Object {
@@ -179,7 +179,7 @@ Array [
     "message": "Expected numeric font-weight notation (font-weight-notation)",
     "range": Object {
       "end": Object {
-        "character": 29,
+        "character": 30,
         "line": 2,
       },
       "start": Object {
@@ -198,7 +198,7 @@ Array [
     "message": "Expected numeric font-weight notation (font-weight-notation)",
     "range": Object {
       "end": Object {
-        "character": 6,
+        "character": 7,
         "line": 4,
       },
       "start": Object {
@@ -222,7 +222,7 @@ Array [
     "message": "Unexpected unit (length-zero-no-unit)",
     "range": Object {
       "end": Object {
-        "character": 10,
+        "character": 11,
         "line": 3,
       },
       "start": Object {
@@ -247,7 +247,7 @@ Object {
       "message": "Unexpected unknown type selector \\"unknown\\" (selector-type-no-unknown)",
       "range": Object {
         "end": Object {
-          "character": 0,
+          "character": 1,
           "line": 1,
         },
         "start": Object {
@@ -303,7 +303,7 @@ Object {
       "message": "Expected indentation of 2 spaces (indentation)",
       "range": Object {
         "end": Object {
-          "character": 3,
+          "character": 4,
           "line": 1,
         },
         "start": Object {
@@ -326,7 +326,7 @@ Object {
       "message": "Rule \\"foo\\" isn't enabled",
       "range": Object {
         "end": Object {
-          "character": 0,
+          "character": 1,
           "line": 1,
         },
         "start": Object {
@@ -342,7 +342,7 @@ Object {
       "message": "Rule \\"foo\\" isn't enabled",
       "range": Object {
         "end": Object {
-          "character": 0,
+          "character": 1,
           "line": 3,
         },
         "start": Object {
@@ -358,7 +358,7 @@ Object {
       "message": "Rule \\"foo\\" isn't enabled",
       "range": Object {
         "end": Object {
-          "character": 0,
+          "character": 1,
           "line": 5,
         },
         "start": Object {
@@ -384,7 +384,7 @@ Object {
       "message": "Expected indentation of 4 spaces (indentation)",
       "range": Object {
         "end": Object {
-          "character": 2,
+          "character": 3,
           "line": 2,
         },
         "start": Object {
@@ -400,7 +400,7 @@ Object {
       "message": "Needless disable for \\"indentation\\"",
       "range": Object {
         "end": Object {
-          "character": 2,
+          "character": 3,
           "line": 2,
         },
         "start": Object {
@@ -416,7 +416,7 @@ Object {
       "message": "Needless disable for \\"indentation\\"",
       "range": Object {
         "end": Object {
-          "character": 0,
+          "character": 1,
           "line": 6,
         },
         "start": Object {
@@ -432,7 +432,7 @@ Object {
       "message": "Needless disable for \\"indentation\\"",
       "range": Object {
         "end": Object {
-          "character": 16,
+          "character": 17,
           "line": 13,
         },
         "start": Object {
@@ -448,7 +448,7 @@ Object {
       "message": "Needless disable for \\"indentation\\"",
       "range": Object {
         "end": Object {
-          "character": 0,
+          "character": 1,
           "line": 16,
         },
         "start": Object {
@@ -471,7 +471,7 @@ Object {
       "message": "Fake result",
       "range": Object {
         "end": Object {
-          "character": 0,
+          "character": 1,
           "line": 0,
         },
         "start": Object {
@@ -497,7 +497,7 @@ Object {
       "message": "Expected indentation of 2 spaces (indentation)",
       "range": Object {
         "end": Object {
-          "character": 3,
+          "character": 4,
           "line": 1,
         },
         "start": Object {


### PR DESCRIPTION
Fixes #323

Adjusts diagnostic creation to send [start, end) ranges instead of [start, end]. Works around VS Code's inconsistent behaviour in which problems that are displayed for a single character may have a smaller hover region than the underline visual.