### PR TITLE
chore: update jest-runner-vscode to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "fast-glob": "^3.2.7",
         "fs-extra": "^10.0.0",
         "jest": "^27.4.3",
-        "jest-runner-vscode": "^2.0.0",
+        "jest-runner-vscode": "^2.1.0",
         "jsonc-parser": "^3.0.0",
         "npm-run-all": "^4.1.5",
         "p-wait-for": "^3.1.0",
@@ -3480,6 +3480,15 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "node_modules/easy-stack": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.1.tgz",
+      "integrity": "sha512-wK2sCs4feiiJeFXn3zvY0p41mdU5VUgbgs1rNsc/y5ngFUijdWd+iIN8eoyuZHKB8xN6BL4PdWmzqFmxNg6V2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.3.886",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.886.tgz",
@@ -4442,6 +4451,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-pubsub": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/event-pubsub/-/event-pubsub-4.3.0.tgz",
+      "integrity": "sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/execa": {
@@ -6741,20 +6759,24 @@
       }
     },
     "node_modules/jest-runner-vscode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jest-runner-vscode/-/jest-runner-vscode-2.0.0.tgz",
-      "integrity": "sha512-nY8t6vxa+hd5XKm41XJnA4HwBzoc2UfgZ2rwo48UxR6dMjd2pgk+nhY1zx1DQerzFgJ2sTsbcv8yStEYNoFErQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jest-runner-vscode/-/jest-runner-vscode-2.1.0.tgz",
+      "integrity": "sha512-69frE9umIx2AAu5QG79XB2B3XofXq452LsEkfEdtWOrXmC4AzjQGWKns2E/JkYb1LsLsf1upKjWlYs3Gs/HsKQ==",
       "dev": true,
       "dependencies": {
         "@jest/core": "^27.2.1",
         "@vscode/test-electron": "^1.6.2",
         "cosmiconfig": "^7.0.1",
         "jest-cli": "^27.2.1",
-        "jest-environment-node": "^27.2.0"
+        "jest-environment-node": "^27.2.0",
+        "node-ipc": "^9.0.0"
       },
       "engines": {
         "node": ">=14.16.0",
         "vscode": ">=1.56.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/adalinesimonian"
       }
     },
     "node_modules/jest-runner/node_modules/ansi-styles": {
@@ -7364,6 +7386,27 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-message": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.7.tgz",
+      "integrity": "sha512-efJLHhLjIyKRewNS9EGZ4UpI8NguuL6fKkhRxVuMmrGV2xN/0APGdQYwLFky5w9naebSZ0OwAGp0G6/2Cg90rA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/js-queue": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.2.tgz",
+      "integrity": "sha512-pbKLsbCfi7kriM3s1J4DDCo7jQkI58zPLHi0heXPzPlj0hjUsm+FesPUbE0DSbIVIK503A36aUBoCN7eMFedkA==",
+      "dev": true,
+      "dependencies": {
+        "easy-stack": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=1.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7959,6 +8002,20 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
+    },
+    "node_modules/node-ipc": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.2.1.tgz",
+      "integrity": "sha512-mJzaM6O3xHf9VT8BULvJSbdVbmHUKRNOH7zDDkCrA1/T+CVjq2WVIDfLt0azZRXpgArJtl3rtmEozrbXPZ9GaQ==",
+      "dev": true,
+      "dependencies": {
+        "event-pubsub": "4.3.0",
+        "js-message": "1.0.7",
+        "js-queue": "2.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/node-modules-regexp": {
       "version": "1.0.0",
@@ -13363,6 +13420,12 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "easy-stack": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.1.tgz",
+      "integrity": "sha512-wK2sCs4feiiJeFXn3zvY0p41mdU5VUgbgs1rNsc/y5ngFUijdWd+iIN8eoyuZHKB8xN6BL4PdWmzqFmxNg6V2w==",
+      "dev": true
+    },
     "electron-to-chromium": {
       "version": "1.3.886",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.886.tgz",
@@ -14014,6 +14077,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "event-pubsub": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/event-pubsub/-/event-pubsub-4.3.0.tgz",
+      "integrity": "sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ==",
       "dev": true
     },
     "execa": {
@@ -15772,16 +15841,17 @@
       }
     },
     "jest-runner-vscode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jest-runner-vscode/-/jest-runner-vscode-2.0.0.tgz",
-      "integrity": "sha512-nY8t6vxa+hd5XKm41XJnA4HwBzoc2UfgZ2rwo48UxR6dMjd2pgk+nhY1zx1DQerzFgJ2sTsbcv8yStEYNoFErQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jest-runner-vscode/-/jest-runner-vscode-2.1.0.tgz",
+      "integrity": "sha512-69frE9umIx2AAu5QG79XB2B3XofXq452LsEkfEdtWOrXmC4AzjQGWKns2E/JkYb1LsLsf1upKjWlYs3Gs/HsKQ==",
       "dev": true,
       "requires": {
         "@jest/core": "^27.2.1",
         "@vscode/test-electron": "^1.6.2",
         "cosmiconfig": "^7.0.1",
         "jest-cli": "^27.2.1",
-        "jest-environment-node": "^27.2.0"
+        "jest-environment-node": "^27.2.0",
+        "node-ipc": "^9.0.0"
       }
     },
     "jest-runtime": {
@@ -16190,6 +16260,21 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "js-message": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.7.tgz",
+      "integrity": "sha512-efJLHhLjIyKRewNS9EGZ4UpI8NguuL6fKkhRxVuMmrGV2xN/0APGdQYwLFky5w9naebSZ0OwAGp0G6/2Cg90rA==",
+      "dev": true
+    },
+    "js-queue": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.2.tgz",
+      "integrity": "sha512-pbKLsbCfi7kriM3s1J4DDCo7jQkI58zPLHi0heXPzPlj0hjUsm+FesPUbE0DSbIVIK503A36aUBoCN7eMFedkA==",
+      "dev": true,
+      "requires": {
+        "easy-stack": "^1.0.1"
       }
     },
     "js-tokens": {
@@ -16655,6 +16740,17 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
+    },
+    "node-ipc": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.2.1.tgz",
+      "integrity": "sha512-mJzaM6O3xHf9VT8BULvJSbdVbmHUKRNOH7zDDkCrA1/T+CVjq2WVIDfLt0azZRXpgArJtl3rtmEozrbXPZ9GaQ==",
+      "dev": true,
+      "requires": {
+        "event-pubsub": "4.3.0",
+        "js-message": "1.0.7",
+        "js-queue": "2.0.2"
+      }
     },
     "node-modules-regexp": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "fast-glob": "^3.2.7",
     "fs-extra": "^10.0.0",
     "jest": "^27.4.3",
-    "jest-runner-vscode": "^2.0.0",
+    "jest-runner-vscode": "^2.1.0",
     "jsonc-parser": "^3.0.0",
     "npm-run-all": "^4.1.5",
     "p-wait-for": "^3.1.0",

--- a/test/e2e/jest-runner-vscode.config.js
+++ b/test/e2e/jest-runner-vscode.config.js
@@ -9,6 +9,7 @@ const config = {
 	openInFolder: true,
 	workspaceDir: path.join(__dirname, 'workspace/workspace.code-workspace'),
 	extensionDevelopmentPath: path.join(__dirname, '../..'),
+	filterOutput: true,
 };
 
 module.exports = config;


### PR DESCRIPTION
> See https://github.com/adalinesimonian/jest-runner-vscode/releases/tag/v2.1.0

The new version of jest-runner-vscode uses IPC for better test reporting and less lag when tests fail.