### PR TITLE
Add VSCode Stylelint Contributors, Sponsors, and Backers

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ cmd /C "set NODE_ENV=development&&code"
 
 ## Contributors
 
-Stylelint is maintained by volunteers. Without the code contributions from [all these fantastic people](https://github.com/stylelint/vscode-stylelint/graphs/contributors), Stylelint would not exist. [Become a contributor](CONTRIBUTING.md).
+Stylelint is maintained by volunteers. Without the code contributions from [all these fantastic people](https://github.com/stylelint/vscode-stylelint/graphs/contributors), Stylelint would not exist. [Become a contributor](https://github.com/stylelint/vscode-stylelint/contribute).
 
 ### Sponsors
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,26 @@ And on Windows by running:
 cmd /C "set NODE_ENV=development&&code"
 ```
 
+## Contributors
+
+Stylelint is maintained by volunteers. Without the code contributions from [all these fantastic people](https://github.com/stylelint/vscode-stylelint/graphs/contributors), Stylelint would not exist. [Become a contributor](CONTRIBUTING.md).
+
+### Sponsors
+
+<object data="https://opencollective.com/stylelint/sponsors.svg?width=420&button=false" type="image/svg+xml">
+  <img src="https://opencollective.com/stylelint/sponsors.svg?width=840&button=false" />
+</object>
+
+Thank you to all our sponsors! [Become a sponsor](https://opencollective.com/stylelint).
+
+### Backers
+
+<object data="https://opencollective.com/stylelint/backers.svg?width=420&avatarHeight=48&button=false" type="image/svg+xml">
+  <img src="https://opencollective.com/stylelint/backers.svg?width=840&avatarHeight=48&button=false" />
+</object>
+
+Thank you to all our backers! [Become a backer](https://opencollective.com/stylelint).
+
 ## Licence
 
 [MIT](LICENSE)


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

Whilst looking at the extension page of another VSCode extension I noticed that this extension included their Open Collective sponsors in the readme, I think we should do the same, so here's a PR doing just that copied from the main Stylelint repo

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation tweak

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
