### PR TITLE
docs: fix "stylelint configuration file" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ cmd /C "set NODE_ENV=development&&code"
 
 [stylelint]: https://stylelint.io/
 [stylelint getting started guide]: https://stylelint.io/user-guide/get-started
-[stylelint configuration file]: https://stylelint.io/user-guide/configuration
+[stylelint configuration file]: https://stylelint.io/user-guide/configure
 [stylelint 14 migration guide]: https://github.com/stylelint/stylelint/blob/main/docs/migration-guide/to-14.md
 [`customsyntax`]: https://stylelint.io/user-guide/usage/options/#customsyntax
 [`config`]: https://stylelint.io/user-guide/usage/node-api#config


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Current URL (https://stylelint.io/user-guide/configuration) returns error 404. I think that https://stylelint.io/user-guide/configure is the good one.
