### PR TITLE
ci: add Node.js v16 & v18 to `testing.yml` matrix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14]
+        node-version: [ 14, 16, 18]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->
Added addional Node.js verstions to `testing.yml` version matrix, based Stylelint:

https://github.com/stylelint/stylelint/blob/6c747390abdd7e4eac7b40c9530b64592fb7b188/.github/workflows/testing.yml#L28


> Which issue, if any, is this issue related to?

e.g. "Closes #000" or "None, as it's a documentation fix."

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
