### PR TITLE
Revert "chore(deps-dev): bump @vscode/test-electron from 1.6.2 to 2.1.5"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.30.5",
         "@typescript/lib-dom": "npm:@types/web@^0.0.47",
-        "@vscode/test-electron": "^2.1.5",
+        "@vscode/test-electron": "^1.6.2",
         "cspell": "^5.13.1",
         "esbuild": "^0.14.1",
         "eslint": "^8.3.0",
@@ -2273,9 +2273,9 @@
       "dev": true
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.5.tgz",
-      "integrity": "sha512-O/ioqFpV+RvKbRykX2ItYPnbcZ4Hk5V0rY4uhQjQTLhGL9WZUvS7exzuYQCCI+ilSqJpctvxq2llTfGXf9UnnA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.2.tgz",
+      "integrity": "sha512-W01ajJEMx6223Y7J5yaajGjVs1QfW3YGkkOJHVKfAMEqNB1ZHN9wCcViehv5ZwVSSJnjhu6lYEYgwBdHtCxqhQ==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^4.0.1",
@@ -6866,21 +6866,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/adalinesimonian"
-      }
-    },
-    "node_modules/jest-runner-vscode/node_modules/@vscode/test-electron": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.2.tgz",
-      "integrity": "sha512-W01ajJEMx6223Y7J5yaajGjVs1QfW3YGkkOJHVKfAMEqNB1ZHN9wCcViehv5ZwVSSJnjhu6lYEYgwBdHtCxqhQ==",
-      "dev": true,
-      "dependencies": {
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "unzipper": "^0.10.11"
-      },
-      "engines": {
-        "node": ">=8.9.3"
       }
     },
     "node_modules/jest-runner/node_modules/ansi-styles": {
@@ -12598,9 +12583,9 @@
       "dev": true
     },
     "@vscode/test-electron": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.5.tgz",
-      "integrity": "sha512-O/ioqFpV+RvKbRykX2ItYPnbcZ4Hk5V0rY4uhQjQTLhGL9WZUvS7exzuYQCCI+ilSqJpctvxq2llTfGXf9UnnA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.2.tgz",
+      "integrity": "sha512-W01ajJEMx6223Y7J5yaajGjVs1QfW3YGkkOJHVKfAMEqNB1ZHN9wCcViehv5ZwVSSJnjhu6lYEYgwBdHtCxqhQ==",
       "dev": true,
       "requires": {
         "http-proxy-agent": "^4.0.1",
@@ -16023,20 +16008,6 @@
         "jest-cli": "^27.2.1",
         "jest-environment-node": "^27.2.0",
         "node-ipc": "^9.0.0"
-      },
-      "dependencies": {
-        "@vscode/test-electron": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.2.tgz",
-          "integrity": "sha512-W01ajJEMx6223Y7J5yaajGjVs1QfW3YGkkOJHVKfAMEqNB1ZHN9wCcViehv5ZwVSSJnjhu6lYEYgwBdHtCxqhQ==",
-          "dev": true,
-          "requires": {
-            "http-proxy-agent": "^4.0.1",
-            "https-proxy-agent": "^5.0.0",
-            "rimraf": "^3.0.2",
-            "unzipper": "^0.10.11"
-          }
-        }
       }
     },
     "jest-runtime": {

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
     "@typescript-eslint/eslint-plugin": "^5.5.0",
     "@typescript-eslint/parser": "^5.30.5",
     "@typescript/lib-dom": "npm:@types/web@^0.0.47",
-    "@vscode/test-electron": "^2.1.5",
+    "@vscode/test-electron": "^1.6.2",
     "cspell": "^5.13.1",
     "esbuild": "^0.14.1",
     "eslint": "^8.3.0",


### PR DESCRIPTION
Reverts stylelint/vscode-stylelint#412

This update seemed to be the cause of the currently falling tests. I don't remember if the CI for this PR passed at that time 😓