### PR TITLE
feat: add `run` option for postponing validation until the document is saved

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,16 @@
           "additionalProperties": false,
           "description": "Options for the disable lint rule action in the quick fix menu."
         },
+        "stylelint.run": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "onType",
+            "onSave"
+          ],
+          "default": "onType",
+          "description": "Control when Stylelint valiation is performed."
+        },
         "stylelint.config": {
           "scope": "resource",
           "type": [

--- a/src/server/modules/validator.ts
+++ b/src/server/modules/validator.ts
@@ -113,9 +113,21 @@ export class ValidatorModule implements LanguageServerModule {
 
 		this.#logger?.debug('onDidChangeWatchedFiles handler registered');
 
-		this.#context.documents.onDidChangeContent(
-			async ({ document }) => await this.#validate(document),
-		);
+		this.#context.documents.onDidChangeContent(async ({ document }) => {
+			const options = await this.#context.getOptions(document.uri);
+
+			if (options.run !== 'onSave') {
+				await this.#validate(document);
+			}
+		});
+
+		this.#context.documents.onDidSave(async ({ document }) => {
+			const options = await this.#context.getOptions(document.uri);
+
+			if (options.run === 'onSave') {
+				await this.#validate(document);
+			}
+		});
 
 		this.#logger?.debug('onDidChangeContent handler registered');
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -221,6 +221,7 @@ export type LanguageServerOptions = {
 			location: 'separateLine' | 'sameLine';
 		};
 	};
+	run?: 'onType' | 'onSave';
 	config?: stylelint.Config | null;
 	configBasedir?: string;
 	configFile?: string;


### PR DESCRIPTION
This adds the `stylelint.run` option with possible values of `onType` (the default) and `onSave`. The `onType` value exhibits Stylelint's current behavior. The `onSave` value prevents validation until the document is saved. Note that, when `onSave` is used, this PR doesn't explicitly clear (potentially outdated) diagnostics as you type.

> Which issue, if any, is this issue related to?

#445

> Is there anything in the PR that needs further explanation?

N/A
