### PR TITLE
Fixes server/modules/formatter tests

### DIFF
--- a/src/server/modules/__tests__/formatter.ts
+++ b/src/server/modules/__tests__/formatter.ts
@@ -28,13 +28,15 @@ import { Position, TextEdit } from 'vscode-languageserver-types';
 import { Notification } from '../../types';
 import { FormatterModule } from '../formatter';
 
-const mockContext = serverMocks.getContext();
-const mockLogger = serverMocks.getLogger();
+let mockContext = serverMocks.getContext();
+let mockLogger = serverMocks.getLogger();
 
 describe('FormatterModule', () => {
 	beforeEach(() => {
+		jest.restoreAllMocks();
+		mockContext = serverMocks.getContext();
 		mockContext.__options.validate = [];
-		jest.clearAllMocks();
+		mockLogger = serverMocks.getLogger();
 	});
 
 	test('should be constructable', () => {


### PR DESCRIPTION
Fix copied from original PR

https://github.com/stylelint/vscode-stylelint/pull/426/files#diff-f2680deb1906c0920d4e4b4f73879a32a741ed4288aabb2a218a2eef48f38211

Just trying to see if we can help push [feat: Report ranges for diagnostics](https://github.com/stylelint/vscode-stylelint/pull/358) through the finishing line

We tested the branch and it worked nicely!

| Before | After | 
| --- | --- |
| ![Screenshot 2023-03-28 at 16 54 52](https://user-images.githubusercontent.com/905006/228304703-85ec2421-6fdb-4b9e-ba41-86cda320319b.png) | ![Screenshot 2023-03-28 at 16 55 21](https://user-images.githubusercontent.com/905006/228304707-31880cab-4b84-4e5d-9429-abf69ee13aa0.png) |

Even though CI seemed green in the PR, some tests appeared to be failing locally. We just went ahead and borrowed from [refactor: update deps](https://github.com/stylelint/vscode-stylelint/pull/426) the smallest fix we could find that made it green locally too

| Before | After | 
| --- | --- |
| ![Screenshot 2023-03-28 at 17 24 57](https://user-images.githubusercontent.com/905006/228306044-e80eb9d3-445e-46f1-ae56-3eaff0934303.png) | ![Screenshot 2023-03-28 at 17 22 29](https://user-images.githubusercontent.com/905006/228306074-f514d5c0-c94f-43aa-b6e7-29537438f6d0.png) |

cc @samrose3