### PR TITLE
Remove "less" from defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,6 @@
           },
           "default": [
             "css",
-            "less",
             "postcss"
           ],
           "description": "An array of language ids which snippets are provided by Stylelint."

--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
           },
           "default": [
             "css",
-            "less",
             "postcss"
           ],
           "description": "An array of language ids which should be validated by Stylelint."


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

This brings the default configuration for `stylelint.validate` in line with [the readme](https://github.com/stylelint/vscode-stylelint#:~:text=In%20current%20versions%20of%20the%20extension%2C%20the%20extension%20only%20supports%20validating%20CSS%20and%20PostCSS%20out%20of%20the%20box), which states:

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"In current versions of the extension, the extension only supports validating CSS and PostCSS out of the box"

Should `"less"` also be removed from the default value for `stylelint.snippet`? I have now added a commit to do that, based on the history below.

**History:**

- First removed in [`a4e0454`](https://github.com/stylelint/vscode-stylelint/commit/a4e0454523d1d35c76fd8033a36498c384242234) by @adalinesimonian 
- Added back in [#270](https://github.com/stylelint/vscode-stylelint/pull/270) by @adalinesimonian
- Removed from documentation in [#280](https://github.com/stylelint/vscode-stylelint/pull/280) (but not removed from `package.json` again) by @adalinesimonian 