### PR TITLE
Add Sponsor badge to extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "homepage": "https://github.com/stylelint/vscode-stylelint#readme",
   "bugs": "https://github.com/stylelint/vscode-stylelint/issues",
   "qna": "https://stackoverflow.com/questions/tagged/vscode+stylelint",
+  "sponsor": {
+    "url": "https://opencollective.com/stylelint"
+  },
   "icon": "media/stylelint.png",
   "engines": {
     "vscode": ">=1.56.0",


### PR DESCRIPTION
You can have the Sponsor badge appear in the header on the marketplace. Example here: marketplace.visualstudio.com/items?itemName=HTMLHint.vscode-htmlhint.

To add that to the extension you just need to add this to the extension's package.json

```json
  "sponsor": {
    "url": "https://opencollective.com/stylelint"
  }
```

> Which issue, if any, is this issue related to?

Partial fix for #433