### PR TITLE
Configure Dependabot for Jest dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     versioning-strategy: increase
     labels:
       - 'pr: dependencies'
+    groups:
+      jest:
+        patterns: ['jest', 'jest-runner-vscode', 'ts-jest', '@types/jest']
     ignore:
       - dependency-name: p-wait-for
         update-types: [version-update:semver-major]


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #429

> Is there anything in the PR that needs further explanation?

We have to bump Jest-related packages at the same time, especially for major updates.

Also, this PR will reduce the number of Dependabot PRs.

---
We can see the related dependencies in `package.json` as below:

```sh-session
$ git grep 'jest' package.json
package.json:225:    "@types/jest": "^27.0.3",
package.json:240:    "jest": "^27.4.3",
package.json:241:    "jest-runner-vscode": "^2.1.0",
package.json:253:    "ts-jest": "^27.0.7",
package.json:275:    "test": "npm run build-bundle && jest",
package.json:276:    "test:e2e": "npm run build-bundle && jest --projects test/e2e",
package.json:277:    "test:integration": "jest --projects test/integration",
package.json:278:    "test:unit": "jest --projects test/unit",
```

