### PR TITLE
Fix build warning for `require.resolve()`

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -1,22 +1,22 @@
-import { EventEmitter } from 'events';
-// eslint-disable-next-line n/no-missing-import
+import { EventEmitter } from 'node:events';
+import path from 'node:path';
+
 import { LanguageClient, SettingMonitor, ExecuteCommandRequest } from 'vscode-languageclient/node';
-import { workspace, commands, window } from 'vscode';
+import { workspace, commands, window, type ExtensionContext } from 'vscode';
 import { ApiEvent, PublicApi } from './types';
 import {
 	CommandId,
 	DidRegisterDocumentFormattingEditProviderNotificationParams,
 	Notification,
 } from '../server/index';
-import type vscode from 'vscode';
 
 let client: LanguageClient;
 
 /**
  * Activates the extension.
  */
-export async function activate({ subscriptions }: vscode.ExtensionContext): Promise<PublicApi> {
-	const serverPath = require.resolve('./start-server');
+export async function activate({ subscriptions }: ExtensionContext): Promise<PublicApi> {
+	const serverPath = path.join(__dirname, 'start-server.js');
 
 	const api = Object.assign(new EventEmitter(), { codeActionReady: false }) as PublicApi;
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events';
 import path from 'node:path';
 
+// eslint-disable-next-line n/no-missing-import
 import { LanguageClient, SettingMonitor, ExecuteCommandRequest } from 'vscode-languageclient/node';
 import { workspace, commands, window, type ExtensionContext } from 'vscode';
 import { ApiEvent, PublicApi } from './types';


### PR DESCRIPTION
This change doesn't use `require.resolve()` to prevent the build warning below:

```sh-session
$ npm run bundle

> vscode-stylelint@1.3.0 bundle
> npm run bundle-base -- --sourcemap

> vscode-stylelint@1.3.0 bundle-base
> ts-node --transpile-only -P tsconfig.scripts.json scripts/bundle.ts --sourcemap

▲ [WARNING] "./start-server" should be marked as external for use with "require.resolve"

    build/extension/extension.js:13:39:
      13 │     const serverPath = require.resolve('./start-server');
         ╵                                        ~~~~~~~~~~~~~~~~

1 warning
```

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
