### PR TITLE
chore: Fix debugging launch profiles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,8 +13,10 @@
 				"--disable-extensions",
 				"--trace-warnings"
 			],
-			"env": { "NODE_ENV": "development" },
-			"stopOnEntry": false
+			"outFiles": [
+				"${workspaceFolder}/**/*.(m|c|)js",
+				"!**/node_modules/**"
+			]
 		},
 		{
 			"type": "node",
@@ -23,8 +25,10 @@
 			"address": "localhost",
 			"protocol": "inspector",
 			"port": 6004,
-			"sourceMaps": false,
-			"outFiles": ["${workspaceRoot}/server.js"]
+			"outFiles": [
+				"${workspaceFolder}/**/*.(m|c|)js",
+				"!**/node_modules/**"
+			]
 		},
 		{
 			"name": "Launch Tests",


### PR DESCRIPTION
* Updates `outFile` fields to point to dist
* removes `stopEntry` since it is not allowed in the extension host
* removes `sourceMaps: false` in server profile

The above changes lets developers debug all parts of the stylelint code