### PR TITLE
chore(deps-dev): exclude `eslint` from Dependabot group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,8 @@ updates:
       jest:
         patterns: ['jest', 'ts-jest', '@types/jest']
       eslint:
-        patterns: ['eslint', 'eslint-config-*', '@typescript-eslint/*']
+        # TODO: Re-add 'eslint' when it's possible to bump ESLint to v9.
+        patterns: ['eslint-config-*', '@typescript-eslint/*']
       vscode:
         patterns: ['vscode-*', '@vscode/*']
     ignore:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See #584

> Is there anything in the PR that needs further explanation?

This project is not yet ready for ESLint v9. For example, see #584.
