### PR TITLE
Fix flaky E2E test

### DIFF
--- a/test/e2e/__tests__/custom-syntax.ts
+++ b/test/e2e/__tests__/custom-syntax.ts
@@ -8,15 +8,17 @@ describe('"stylelint.customSyntax" setting', () => {
 	});
 
 	it('should auto-fix using the specified custom syntax', async () => {
-		const { document } = await openDocument('custom-syntax/test.css');
+		const { document } = await openDocument('custom-syntax/test.scss');
 
 		await executeAutofix();
 
 		assert.equal(
 			document.getText(),
 			`/* prettier-ignore */
-.foo .bar
-  color: #ffffff`,
+.foo .bar {
+  color: #fff;
+}
+`,
 		);
 	});
 });

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -34,7 +34,11 @@ async function getWorkspaceFile(filePath: string): Promise<Uri> {
 
 	const files = await workspace.findFiles(new RelativePattern(workspaceFolder, fileName));
 
-	assert.equal(files.length, 1);
+	assert.equal(
+		files.length,
+		1,
+		`The number of the "${fileName}" files in the "${workspaceName}" workspace must be 1`,
+	);
 
 	return files[0];
 }

--- a/test/e2e/workspace/custom-syntax/custom-syntax.js
+++ b/test/e2e/workspace/custom-syntax/custom-syntax.js
@@ -1,4 +1,3 @@
 'use strict';
 
-//@ts-expect-error - no type definitions
-module.exports = require('../../../../node_modules/postcss-sass');
+module.exports = require('../../../../node_modules/postcss-scss');

--- a/test/e2e/workspace/custom-syntax/test.scss
+++ b/test/e2e/workspace/custom-syntax/test.scss
@@ -1,3 +1,4 @@
 /* prettier-ignore */
-.foo .bar
+.foo .bar {
   color: #fff;
+}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

The current E2E test often fails with the `stylelint.customSyntax` case. E.g.

```
  "stylelint.customSyntax" setting
[main 2025-03-06T15:39:38.577Z] CodeWindow: renderer process gone (reason: crashed, code: -36861)
[main 2025-03-06T15:39:38.603Z] Extension host with pid 2176 exited with code: 0, signal: unknown.
Error sending from webFrameMain:  Error: Render frame was disposed before WebFrameMain could be accessed
    at s.send (node:electron/js2c/browser_init:2:93948)
    at _.send (node:electron/js2c/browser_init:2:79174)
```

https://github.com/stylelint/vscode-stylelint/actions/runs/13701322508/job/38319300464#step:11:57

I'm still unsure why, but I found that replacing `postcss-sass` with `postcss-scss` in the test fixture improves the test stability.

---

The first attempt was successful! 🎉 
https://github.com/stylelint/vscode-stylelint/actions/runs/13702755871?pr=644
