### PR TITLE
chore: bump oldest supported vscode to 1.83.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/path-is-inside": "^1.0.3",
         "@types/semver": "^7.5.8",
         "@types/triple-beam": "^1.3.5",
-        "@types/vscode": "1.82.0",
+        "@types/vscode": "1.83.0",
         "@typescript-eslint/eslint-plugin": "^8.3.0",
         "@typescript-eslint/parser": "^8.3.0",
         "@vscode/test-cli": "^0.0.10",
@@ -58,7 +58,7 @@
         "typescript": "^5.5.4"
       },
       "engines": {
-        "vscode": ">=1.82.3"
+        "vscode": ">=1.83.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3171,10 +3171,11 @@
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
     },
     "node_modules/@types/vscode": {
-      "version": "1.82.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
-      "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
-      "dev": true
+      "version": "1.83.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.83.0.tgz",
+      "integrity": "sha512-3mUtHqLAVz9hegut9au4xehuBrzRE3UJiQMpoEHkNl6XHliihO7eATx2BMHs0odsmmrwjJrlixx/Pte6M3ygDQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "icon": "media/stylelint.png",
   "engines": {
-    "vscode": ">=1.82.3"
+    "vscode": ">=1.83.0"
   },
   "galleryBanner": {
     "color": "#000000",
@@ -220,7 +220,7 @@
     "@types/path-is-inside": "^1.0.3",
     "@types/semver": "^7.5.8",
     "@types/triple-beam": "^1.3.5",
-    "@types/vscode": "1.82.0",
+    "@types/vscode": "1.83.0",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "@typescript-eslint/parser": "^8.3.0",
     "@vscode/test-cli": "^0.0.10",
@@ -262,7 +262,7 @@
     "lint:types": "tsc -b",
     "lint:unit-tests": "ts-node --transpile-only -P tsconfig.scripts.json scripts/enforce-unit-tests-per-file.ts",
     "test": "npm run build-bundle && npm run jest -- ",
-    "test:e2e": "npm run build-bundle && vscode-test",
+    "test:e2e": "npm run build-bundle && vscode-test && prettier -w --parser jsonc test/e2e/workspace/workspace.code-workspace",
     "test:integration": "npm run jest -- --projects test/integration",
     "test:unit": "npm run jest -- --projects test/unit",
     "test:node-versions": "node scripts/test-node-versions.js",

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -66,7 +66,7 @@ type WaitForOptions = {
 export async function waitFor<T>(
 	produce: () => T,
 	condition: (result: T) => boolean,
-	{ timeout = 5000, interval = 20 }: WaitForOptions = {},
+	{ timeout = 10000, interval = 20 }: WaitForOptions = {},
 ): Promise<T> {
 	let intervalRef: NodeJS.Timer;
 	let timeoutRef: NodeJS.Timeout;


### PR DESCRIPTION
May potentially fix e2e test flakiness observed in https://github.com/stylelint/vscode-stylelint/actions/runs/13701322508. An update is nonetheless due. Will likely need to update to a newer version than 1.83, but that may require changes to tests, so this is a stepping stone.