### PR TITLE
Separate PnP test process

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -80,7 +80,7 @@ const config = {
 			},
 		},
 		{
-			files: ['test/e2e/__tests__/**/*'],
+			files: ['test/e2e/__tests__/**/*', 'test/e2e/pnp/__tests__/**/*'],
 			rules: {
 				'jest/expect-expect': 'off',
 			},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -80,7 +80,7 @@ const config = {
 			},
 		},
 		{
-			files: ['test/e2e/__tests__/**/*', 'test/e2e/pnp/__tests__/**/*'],
+			files: ['test/e2e/**/__tests__/**/*'],
 			rules: {
 				'jest/expect-expect': 'off',
 			},

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -57,7 +57,6 @@ jobs:
           path: .vscode-test
           key: ${{ runner.os }}-vscode-${{ hashFiles('package.json') }}
 
-      # TODO: If E2E flakiness is resolved, we should stop retrying and avoid potentially long CI runs.
       - name: Run end-to-end tests (Linux)
         if: ${{ runner.os == 'Linux' }}
         run: xvfb-run -a npm run test:e2e -- --silent

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -60,21 +60,11 @@ jobs:
       # TODO: If E2E flakiness is resolved, we should stop retrying and avoid potentially long CI runs.
       - name: Run end-to-end tests (Linux)
         if: ${{ runner.os == 'Linux' }}
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          retry_on: error
-          command: xvfb-run -a npm run test:e2e -- --silent
+        run: xvfb-run -a npm run test:e2e -- --silent
 
       - name: Run end-to-end tests (non-Linux)
         if: ${{ runner.os != 'Linux' }}
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          retry_on: error
-          command: npm run test:e2e -- --silent
+        run: npm run test:e2e -- --silent
 
   test-node-versions:
     runs-on: ubuntu-latest

--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -8,13 +8,27 @@ const minimumVscodeVersion = pkg.engines.vscode.match(/^>=(.+)$/)?.[1];
 
 if (!minimumVscodeVersion) throw new Error(`"engines.vscode" is unexpected: ${pkg.engines.vscode}`);
 
-module.exports = defineConfig({
-	files: ['test/e2e/__tests__/**/*.ts'],
-	workspaceFolder: 'test/e2e/workspace/workspace.code-workspace',
-	version: minimumVscodeVersion,
-	mocha: {
-		timeout: 60000,
-		ui: 'bdd',
-		require: ['ts-node/register'],
+module.exports = defineConfig([
+	{
+		files: ['test/e2e/__tests__/**/*.ts'],
+		workspaceFolder: 'test/e2e/workspace/workspace.code-workspace',
+		version: minimumVscodeVersion,
+		mocha: {
+			timeout: 60000,
+			ui: 'bdd',
+			require: ['ts-node/register'],
+		},
 	},
-});
+	{
+		// Because PnP tests apply patches to the Node filesystem,
+		// we run them in a separate process to ensure they don't interfere with other tests.
+		files: ['test/e2e/pnp/__tests__/**/*.ts'],
+		workspaceFolder: 'test/e2e/workspace/workspace.code-workspace',
+		version: minimumVscodeVersion,
+		mocha: {
+			timeout: 60000,
+			ui: 'bdd',
+			require: ['ts-node/register'],
+		},
+	},
+]);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "icon": "media/stylelint.png",
   "engines": {
-    "vscode": ">=1.82.3"
+    "vscode": ">=1.83.0"
   },
   "galleryBanner": {
     "color": "#000000",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "icon": "media/stylelint.png",
   "engines": {
-    "vscode": ">=1.83.0"
+    "vscode": ">=1.82.3"
   },
   "galleryBanner": {
     "color": "#000000",

--- a/test/e2e/__tests__/stylelint-resolution.ts
+++ b/test/e2e/__tests__/stylelint-resolution.ts
@@ -34,32 +34,4 @@ describe('Stylelint resolution', () => {
 			]);
 		});
 	});
-
-	it('should resolve Stylelint using PnP', async () => {
-		const document = await openDocument('defaults/yarn-pnp/test.css');
-		const diagnostics = await waitForDiagnostics(document);
-
-		assertDiagnostics(diagnostics, [
-			{
-				code: 'fake',
-				message: 'Fake result from yarn-pnp',
-				range: [0, 0, 0, 1],
-				severity: 'error',
-			},
-		]);
-	});
-
-	it('should resolve Stylelint using Yarn 2.x PnP', async () => {
-		const document = await openDocument('defaults/yarn-2-pnp/test.css');
-		const diagnostics = await waitForDiagnostics(document);
-
-		assertDiagnostics(diagnostics, [
-			{
-				code: 'fake',
-				message: 'Fake result from yarn-2-pnp',
-				range: [0, 0, 0, 1],
-				severity: 'error',
-			},
-		]);
-	});
 });

--- a/test/e2e/pnp/__tests__/stylelint-resolution.ts
+++ b/test/e2e/pnp/__tests__/stylelint-resolution.ts
@@ -1,0 +1,40 @@
+import {
+	openDocument,
+	waitForDiagnostics,
+	assertDiagnostics,
+	closeAllEditors,
+} from '../../helpers';
+
+describe('Stylelint resolution using PnP', () => {
+	afterEach(async () => {
+		await closeAllEditors();
+	});
+
+	it('should resolve Stylelint using PnP', async () => {
+		const document = await openDocument('defaults/yarn-pnp/test.css');
+		const diagnostics = await waitForDiagnostics(document);
+
+		assertDiagnostics(diagnostics, [
+			{
+				code: 'fake',
+				message: 'Fake result from yarn-pnp',
+				range: [0, 0, 0, 1],
+				severity: 'error',
+			},
+		]);
+	});
+
+	it('should resolve Stylelint using Yarn 2.x PnP', async () => {
+		const document = await openDocument('defaults/yarn-2-pnp/test.css');
+		const diagnostics = await waitForDiagnostics(document);
+
+		assertDiagnostics(diagnostics, [
+			{
+				code: 'fake',
+				message: 'Fake result from yarn-2-pnp',
+				range: [0, 0, 0, 1],
+				severity: 'error',
+			},
+		]);
+	});
+});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to #643

> Is there anything in the PR that needs further explanation?

This PR will separate the PnP test process, stabilizing the tests.
I will revert the other test stabilization changes.

It seems that the PnP tests apply patches to the Node filesystem, which can break other tests.
Presumably the user can just restart the extension and the problem will go away, but this doesn't work within the tests, and the error appears to occur before the extension can be restarted.

