### PR TITLE
Specify safe permissions to lint workflow on CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   lint:
     uses: stylelint/.github/.github/workflows/lint.yml@main
+    permissions:
+      contents: read
 
   test:
     name: Test for Stylelint ${{ matrix.stylelint }} on ${{ matrix.os }}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

This fixes the code scanning alert:
- https://github.com/stylelint/vscode-stylelint/security/code-scanning/6

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
