### PR TITLE
fix: add file watchers for .mjs and .cjs configs

### DIFF
--- a/src/extension/__tests__/__snapshots__/extension.ts.snap
+++ b/src/extension/__tests__/__snapshots__/extension.ts.snap
@@ -31,6 +31,7 @@ exports[`Extension entry point should create a language client 1`] = `
       "fileEvents": [
         undefined,
         undefined,
+        undefined,
       ],
     },
   },

--- a/src/extension/__tests__/extension.ts
+++ b/src/extension/__tests__/extension.ts
@@ -123,9 +123,7 @@ describe('Extension entry point', () => {
 		expect(mockWorkspace.createFileSystemWatcher.mock.calls[1]).toEqual([
 			'**/stylelint.config.{js,cjs,mjs}',
 		]);
-		expect(mockWorkspace.createFileSystemWatcher.mock.calls[2]).toEqual([
-			'**/.stylelintignore',
-		]);
+		expect(mockWorkspace.createFileSystemWatcher.mock.calls[2]).toEqual(['**/.stylelintignore']);
 	});
 
 	it('should register an auto-fix command', async () => {

--- a/src/extension/__tests__/extension.ts
+++ b/src/extension/__tests__/extension.ts
@@ -116,12 +116,15 @@ describe('Extension entry point', () => {
 	it('should watch for changes to Stylelint configuration files', async () => {
 		await activate(mockExtensionContext);
 
-		expect(mockWorkspace.createFileSystemWatcher).toHaveBeenCalledTimes(2);
+		expect(mockWorkspace.createFileSystemWatcher).toHaveBeenCalledTimes(3);
 		expect(mockWorkspace.createFileSystemWatcher.mock.calls[0]).toEqual([
-			'**/.stylelintrc{,.js,.json,.yaml,.yml}',
+			'**/.stylelintrc{,.js,.cjs,.mjs,.json,.yaml,.yml}',
 		]);
 		expect(mockWorkspace.createFileSystemWatcher.mock.calls[1]).toEqual([
-			'**/{stylelint.config.js,.stylelintignore}',
+			'**/stylelint.config.{js,cjs,mjs}',
+		]);
+		expect(mockWorkspace.createFileSystemWatcher.mock.calls[2]).toEqual([
+			'**/.stylelintignore',
 		]);
 	});
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -40,8 +40,9 @@ export async function activate({ subscriptions }: ExtensionContext): Promise<Pub
 			diagnosticCollectionName: 'Stylelint',
 			synchronize: {
 				fileEvents: [
-					workspace.createFileSystemWatcher('**/.stylelintrc{,.js,.json,.yaml,.yml}'),
-					workspace.createFileSystemWatcher('**/{stylelint.config.js,.stylelintignore}'),
+					workspace.createFileSystemWatcher('**/.stylelintrc{,.js,.cjs,.mjs,.json,.yaml,.yml}'),
+					workspace.createFileSystemWatcher('**/stylelint.config.{js,cjs,mjs}'),
+					workspace.createFileSystemWatcher('**/.stylelintignore'),
 				],
 			},
 		},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #647 

> Is there anything in the PR that needs further explanation?

I split `stylelint.config.{js,cjs,mjs}` and `.stylelintignore` into separate watchers for readability and to avoid nested brackets.
