### PR TITLE
Release 1.5.3

### DIFF
--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -10,6 +10,7 @@ jobs:
       contents: write
     steps:
       - name: Check actor permission
+        shell: bash
         run: |
           actor_permission=$(gh api \
             -H "Accept: application/vnd.github+json" \
@@ -25,8 +26,6 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -54,19 +53,9 @@ jobs:
       - name: Create GitHub release
         shell: bash
         run: |
-          # Prepare for a new tag.
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
-
-          # Create and push a Git tag.
           new_version=$(npm pkg get version | tr -d '"')
-          new_tag="v${new_version}"
-          git tag --annotate "${new_version}" -m "${new_version}" "${new_tag}"
-          git push origin "${new_tag}"
-
-          # Create a GitHub release.
-          gh release create "${new_tag}" --generate-notes
-          release_url=$(gh release view "${latest_tag}" --json url --jq '.url')
+          gh release create "v${new_version}" --generate-notes
+          release_url=$(gh release view --json url --jq '.url')
           echo "::notice::${release_url} was created successfully. Adjust the release notes from the changelog to keep the consistency with other releases."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3](https://github.com/stylelint/vscode-stylelint/compare/v1.5.2...v1.5.3) (2025-06-05)
+
+No actual changes.
+
 ## [1.5.2](https://github.com/stylelint/vscode-stylelint/compare/v1.5.1...v1.5.2) (2025-06-05)
 
 No actual changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-stylelint",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-stylelint",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "MIT",
       "dependencies": {
         "fast-diff": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-stylelint",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "MIT",
   "description": "Official Stylelint extension for Visual Studio Code",
   "main": "dist/index.js",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #685

> Is there anything in the PR that needs further explanation?

When I tried the workflow changed in PR #685, the following error occurred with the `git` command:

```
fatal: Failed to resolve 'v1.5.2' as a valid ref.
```

https://github.com/stylelint/vscode-stylelint/actions/runs/15467795091/job/43543973356#step:10:20

To avoid the error, this just removes the use of the `git` command, since `gh release create` automatically creates a tag if it doesn't exist. So, the `git` command is no longer needed for this workflow.
Ref https://cli.github.com/manual/gh_release_create

After this PR is merged, I will try the release workflow again.

Compare: https://github.com/stylelint/vscode-stylelint/compare/v1.5.2...main