### PR TITLE
feat: support overriding rule severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,59 @@ Used to supply a custom path to the Stylelint module.
 
 Controls the package manager to be used to resolve the Stylelint library. This setting only has an effect if the Stylelint library is resolved globally. Valid values are `"npm"` or `"yarn"` or `"pnpm"`.
 
+### `stylelint.rules.customizations`
+
+> Type: `object[]`  
+> Default: `[]`
+
+An array of rule customizations that let you override the severity level of Stylelint rules. This is useful for downgrading errors to warnings, upgrading warnings to errors, or completely suppressing specific rules in the editor.
+
+Each customization object has the following properties:
+
+- `rule`: A string pattern matching the rule name. Supports wildcards and negation patterns:
+  - Exact match: `"color-named"` matches only the `color-named` rule.
+  - Wildcard: `"color-*"` matches all rules starting with `color-`.
+  - Negation: `"!color-*"` matches all rules except those starting with `color-`.
+- `severity`: The severity level to apply.
+  - `"error"`: Show as error (red underline).
+  - `"warn"`: Show as warning (yellow underline).
+  - `"info"`: Show as information (blue underline).
+  - `"off"`: Don't show the diagnostic.
+  - `"default"`: Use the original severity from Stylelint.
+  - `"downgrade"`: Convert errors to warnings, warnings to info messages.
+  - `"upgrade"`: Convert info to warnings, warnings to errors.
+
+Customizations are applied in order, with later rules taking priority over earlier ones. This means that more general patterns should come before more specific ones for the specific rules to override the general ones.
+
+Example:
+
+```json
+{
+  "stylelint.rules.customizations": [
+    {
+      "rule": "font-*",
+      "severity": "info"
+    },
+    {
+      "rule": "!color-*",
+      "severity": "info"
+    },
+    {
+      "rule": "declaration-block-*",
+      "severity": "default"
+    },
+    {
+      "rule": "comment-word-disallowed-list",
+      "severity": "off"
+    },
+    {
+      "rule": "color-named",
+      "severity": "warn"
+    }
+  ]
+}
+```
+
 ### `stylelint.snippet`
 
 > Type: `string[]`  

--- a/package.json
+++ b/package.json
@@ -167,6 +167,39 @@
             "postcss"
           ],
           "description": "An array of language ids which snippets are provided by Stylelint."
+        },
+        "stylelint.rules.customizations": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rule": {
+                "type": "string",
+                "description": "Rule name pattern to match. `*` is treated as a wildcard. Prefix with `!` to match all rules that do NOT match the pattern."
+              },
+              "severity": {
+                "type": "string",
+                "enum": [
+                  "downgrade",
+                  "upgrade",
+                  "error",
+                  "warn",
+                  "info",
+                  "off",
+                  "default"
+                ],
+                "description": "Severity override: `downgrade` converts errors to warnings and warnings to info messages, `upgrade` converts warnings to errors, `default` uses the original severity from Stylelint, or specify exact severity."
+              }
+            },
+            "required": [
+              "rule",
+              "severity"
+            ],
+            "additionalProperties": false
+          },
+          "default": [],
+          "description": "Override severity levels for specific rules."
         }
       }
     },

--- a/src/server/__tests__/__snapshots__/server.ts.snap
+++ b/src/server/__tests__/__snapshots__/server.ts.snap
@@ -259,6 +259,9 @@ exports[`StylelintLanguageServer should allow modules to get fixes for documents
       "reportDescriptionlessDisables": false,
       "reportInvalidScopeDisables": false,
       "reportNeedlessDisables": false,
+      "rules": {
+        "customizations": [],
+      },
       "snippet": [
         "css",
         "postcss",
@@ -291,6 +294,9 @@ exports[`StylelintLanguageServer should allow modules to get fixes for documents
       "reportDescriptionlessDisables": false,
       "reportInvalidScopeDisables": false,
       "reportNeedlessDisables": false,
+      "rules": {
+        "customizations": [],
+      },
       "snippet": [
         "css",
         "postcss",
@@ -329,6 +335,9 @@ exports[`StylelintLanguageServer should allow modules to lint documents using co
       "reportDescriptionlessDisables": false,
       "reportInvalidScopeDisables": false,
       "reportNeedlessDisables": false,
+      "rules": {
+        "customizations": [],
+      },
       "snippet": [
         "css",
         "postcss",
@@ -360,6 +369,9 @@ exports[`StylelintLanguageServer should allow modules to lint documents using co
       "reportDescriptionlessDisables": false,
       "reportInvalidScopeDisables": false,
       "reportNeedlessDisables": false,
+      "rules": {
+        "customizations": [],
+      },
       "snippet": [
         "css",
         "postcss",
@@ -416,6 +428,9 @@ exports[`StylelintLanguageServer when workspace/configuration is available, cont
   "reportDescriptionlessDisables": false,
   "reportInvalidScopeDisables": false,
   "reportNeedlessDisables": false,
+  "rules": {
+    "customizations": [],
+  },
   "snippet": [
     "css",
     "postcss",
@@ -444,6 +459,9 @@ exports[`StylelintLanguageServer when workspace/configuration is available, cont
   "reportDescriptionlessDisables": false,
   "reportInvalidScopeDisables": false,
   "reportNeedlessDisables": false,
+  "rules": {
+    "customizations": [],
+  },
   "snippet": [
     "scss",
   ],
@@ -471,6 +489,9 @@ exports[`StylelintLanguageServer when workspace/configuration is not available, 
   "reportDescriptionlessDisables": false,
   "reportInvalidScopeDisables": false,
   "reportNeedlessDisables": false,
+  "rules": {
+    "customizations": [],
+  },
   "snippet": [
     "css",
     "postcss",
@@ -499,6 +520,9 @@ exports[`StylelintLanguageServer when workspace/configuration is not available, 
   "reportDescriptionlessDisables": false,
   "reportInvalidScopeDisables": false,
   "reportNeedlessDisables": false,
+  "rules": {
+    "customizations": [],
+  },
   "snippet": [
     "css",
     "postcss",
@@ -526,6 +550,9 @@ exports[`StylelintLanguageServer when workspace/configuration is not available, 
   "reportDescriptionlessDisables": false,
   "reportInvalidScopeDisables": false,
   "reportNeedlessDisables": false,
+  "rules": {
+    "customizations": [],
+  },
   "snippet": [
     "css",
     "postcss",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -42,6 +42,9 @@ const defaultOptions: LanguageServerOptions = {
 	reportDescriptionlessDisables: false,
 	reportInvalidScopeDisables: false,
 	reportNeedlessDisables: false,
+	rules: {
+		customizations: [],
+	},
 	snippet: ['css', 'postcss'],
 	stylelintPath: '',
 	validate: ['css', 'postcss'],

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -26,6 +26,34 @@ export const CodeActionKind = {
 };
 
 /**
+ * Severity override types.
+ */
+export type SeverityOverride =
+	| 'downgrade'
+	| 'upgrade'
+	| 'error'
+	| 'warn'
+	| 'info'
+	| 'off'
+	| 'default';
+
+/**
+ * Rule customization for severity overrides.
+ */
+export type RuleCustomization = {
+	/**
+	 * Rule name pattern to match. Use `*` to match all rules.
+	 */
+	rule: string;
+
+	/**
+	 * Severity override. `downgrade` converts errors to warnings, `upgrade` converts warnings to errors,
+	 * or specify exact severity.
+	 */
+	severity: SeverityOverride;
+};
+
+/**
  * Language server notification names.
  */
 export enum Notification {
@@ -236,6 +264,9 @@ export type LanguageServerOptions = {
 	reportDescriptionlessDisables?: boolean;
 	reportInvalidScopeDisables?: boolean;
 	reportNeedlessDisables?: boolean;
+	rules?: {
+		customizations?: RuleCustomization[];
+	};
 	snippet: string[];
 	stylelintPath?: string;
 	validate: string[];

--- a/src/utils/stylelint/__tests__/severity-override.ts
+++ b/src/utils/stylelint/__tests__/severity-override.ts
@@ -1,0 +1,303 @@
+import { warningToDiagnostic } from '../warning-to-diagnostic';
+import { DiagnosticSeverity } from 'vscode-languageserver-types';
+import type { Warning } from 'stylelint';
+import type { RuleCustomization } from '../../../server/types';
+
+describe('warningToDiagnostic severity override', () => {
+	const createWarning = (rule: string, severity: 'error' | 'warning' = 'error'): Warning => ({
+		rule,
+		severity,
+		text: `Test message for ${rule}`,
+		line: 1,
+		column: 1,
+	});
+
+	test('should apply exact rule match customization', () => {
+		const warning = createWarning('color-named', 'error');
+		const customizations: RuleCustomization[] = [{ rule: 'color-named', severity: 'warn' }];
+
+		const diagnostic = warningToDiagnostic(warning, undefined, customizations);
+
+		expect(diagnostic).not.toBeNull();
+		expect(diagnostic!.severity).toBe(DiagnosticSeverity.Warning);
+	});
+
+	test('should apply wildcard rule match customization', () => {
+		const warning = createWarning('color-named', 'error');
+		const customizations: RuleCustomization[] = [{ rule: 'color-*', severity: 'info' }];
+
+		const diagnostic = warningToDiagnostic(warning, undefined, customizations);
+
+		expect(diagnostic).not.toBeNull();
+		expect(diagnostic!.severity).toBe(DiagnosticSeverity.Information);
+	});
+
+	test('should suppress diagnostic with "off" severity', () => {
+		const warning = createWarning('color-named', 'error');
+		const customizations: RuleCustomization[] = [{ rule: 'color-named', severity: 'off' }];
+
+		const diagnostic = warningToDiagnostic(warning, undefined, customizations);
+
+		expect(diagnostic).toBeNull();
+	});
+
+	test('should downgrade error to warning', () => {
+		const warning = createWarning('color-named', 'error');
+		const customizations: RuleCustomization[] = [{ rule: 'color-named', severity: 'downgrade' }];
+
+		const diagnostic = warningToDiagnostic(warning, undefined, customizations);
+
+		expect(diagnostic).not.toBeNull();
+		expect(diagnostic!.severity).toBe(DiagnosticSeverity.Warning);
+	});
+
+	test('should upgrade warning to error', () => {
+		const warning = createWarning('color-named', 'warning');
+		const customizations: RuleCustomization[] = [{ rule: 'color-named', severity: 'upgrade' }];
+
+		const diagnostic = warningToDiagnostic(warning, undefined, customizations);
+
+		expect(diagnostic).not.toBeNull();
+		expect(diagnostic!.severity).toBe(DiagnosticSeverity.Error);
+	});
+
+	test('should downgrade warning to info', () => {
+		const warning = createWarning('color-named', 'warning');
+		const customizations: RuleCustomization[] = [{ rule: 'color-named', severity: 'downgrade' }];
+
+		const diagnostic = warningToDiagnostic(warning, undefined, customizations);
+
+		expect(diagnostic).not.toBeNull();
+		expect(diagnostic!.severity).toBe(DiagnosticSeverity.Information);
+	});
+
+	test('should not upgrade error when using upgrade', () => {
+		const warning = createWarning('color-named', 'error');
+		const customizations: RuleCustomization[] = [{ rule: 'color-named', severity: 'upgrade' }];
+
+		const diagnostic = warningToDiagnostic(warning, undefined, customizations);
+
+		expect(diagnostic).not.toBeNull();
+		expect(diagnostic!.severity).toBe(DiagnosticSeverity.Error);
+	});
+
+	test('should use first matching customization', () => {
+		const warning = createWarning('color-named', 'error');
+		const customizations: RuleCustomization[] = [
+			{ rule: 'color-named', severity: 'off' },
+			{ rule: 'color-*', severity: 'info' },
+			{ rule: 'color-named', severity: 'warn' },
+		];
+
+		const diagnostic = warningToDiagnostic(warning, undefined, customizations);
+
+		expect(diagnostic).not.toBeNull();
+		expect(diagnostic!.severity).toBe(DiagnosticSeverity.Warning);
+	});
+
+	test('should use original error severity when no customization matches', () => {
+		const warning = createWarning('color-named', 'error');
+		const customizations: RuleCustomization[] = [{ rule: 'font-family-*', severity: 'warn' }];
+
+		const diagnostic = warningToDiagnostic(warning, undefined, customizations);
+
+		expect(diagnostic).not.toBeNull();
+		expect(diagnostic!.severity).toBe(DiagnosticSeverity.Error);
+	});
+
+	test('should use original warning severity when no customization matches', () => {
+		const warning = createWarning('color-named', 'warning');
+		const customizations: RuleCustomization[] = [{ rule: 'font-family-*', severity: 'error' }];
+
+		const diagnostic = warningToDiagnostic(warning, undefined, customizations);
+
+		expect(diagnostic).not.toBeNull();
+		expect(diagnostic!.severity).toBe(DiagnosticSeverity.Warning);
+	});
+
+	test('should use original severity when no customizations provided', () => {
+		const warningError = createWarning('color-named', 'error');
+		const warningWarn = createWarning('color-named', 'warning');
+
+		const diagnosticError = warningToDiagnostic(warningError, undefined, []);
+		const diagnosticWarn = warningToDiagnostic(warningWarn, undefined, []);
+
+		expect(diagnosticError).not.toBeNull();
+		expect(diagnosticError!.severity).toBe(DiagnosticSeverity.Error);
+		expect(diagnosticWarn).not.toBeNull();
+		expect(diagnosticWarn!.severity).toBe(DiagnosticSeverity.Warning);
+	});
+
+	test('should handle complex wildcard patterns', () => {
+		const warning1 = createWarning('declaration-block-no-duplicate-properties', 'error');
+		const warning2 = createWarning('block-no-empty', 'error');
+		const warning3 = createWarning('color-named', 'error');
+
+		const customizations: RuleCustomization[] = [
+			{ rule: '*-block-*', severity: 'warn' },
+			{ rule: 'block-*', severity: 'info' },
+			{ rule: 'color-*', severity: 'warn' },
+		];
+
+		const diagnostic1 = warningToDiagnostic(warning1, undefined, customizations);
+		const diagnostic2 = warningToDiagnostic(warning2, undefined, customizations);
+		const diagnostic3 = warningToDiagnostic(warning3, undefined, customizations);
+
+		expect(diagnostic1).not.toBeNull();
+		expect(diagnostic1!.severity).toBe(DiagnosticSeverity.Warning);
+
+		expect(diagnostic2).not.toBeNull();
+		expect(diagnostic2!.severity).toBe(DiagnosticSeverity.Information);
+
+		expect(diagnostic3).not.toBeNull();
+		expect(diagnostic3!.severity).toBe(DiagnosticSeverity.Warning);
+	});
+
+	test('should apply negation pattern - exact match', () => {
+		const warning1 = createWarning('color-named', 'error');
+		const warning2 = createWarning('font-family-no-missing-generic-family-keyword', 'error');
+
+		const customizations: RuleCustomization[] = [{ rule: '!color-named', severity: 'warn' }];
+
+		const diagnostic1 = warningToDiagnostic(warning1, undefined, customizations);
+		const diagnostic2 = warningToDiagnostic(warning2, undefined, customizations);
+
+		// color-named should NOT match.
+		expect(diagnostic1).not.toBeNull();
+		expect(diagnostic1!.severity).toBe(DiagnosticSeverity.Error);
+
+		// font-family rule SHOULD match negation.
+		expect(diagnostic2).not.toBeNull();
+		expect(diagnostic2!.severity).toBe(DiagnosticSeverity.Warning);
+	});
+
+	test('should apply negation pattern - wildcard', () => {
+		const warning1 = createWarning('color-named', 'error');
+		const warning2 = createWarning('color-hex-length', 'error');
+		const warning3 = createWarning('font-family-no-missing-generic-family-keyword', 'error');
+
+		const customizations: RuleCustomization[] = [{ rule: '!color-*', severity: 'info' }];
+
+		const diagnostic1 = warningToDiagnostic(warning1, undefined, customizations);
+		const diagnostic2 = warningToDiagnostic(warning2, undefined, customizations);
+		const diagnostic3 = warningToDiagnostic(warning3, undefined, customizations);
+
+		// color-* rules should NOT match, keeping their original severity.
+		expect(diagnostic1).not.toBeNull();
+		expect(diagnostic1!.severity).toBe(DiagnosticSeverity.Error);
+		expect(diagnostic2).not.toBeNull();
+		expect(diagnostic2!.severity).toBe(DiagnosticSeverity.Error);
+
+		// non-color rule SHOULD match negation and be overridden.
+		expect(diagnostic3).not.toBeNull();
+		expect(diagnostic3!.severity).toBe(DiagnosticSeverity.Information);
+	});
+
+	test('should handle negation pattern with "off" severity', () => {
+		const warning1 = createWarning('color-named', 'error');
+		const warning2 = createWarning('font-family-no-missing-generic-family-keyword', 'error');
+
+		const customizations: RuleCustomization[] = [{ rule: '!color-*', severity: 'off' }];
+
+		const diagnostic1 = warningToDiagnostic(warning1, undefined, customizations);
+		const diagnostic2 = warningToDiagnostic(warning2, undefined, customizations);
+
+		// color-* rules should NOT match.
+		expect(diagnostic1).not.toBeNull();
+		expect(diagnostic1!.severity).toBe(DiagnosticSeverity.Error);
+
+		// non-color rule SHOULD match negation and get suppressed.
+		expect(diagnostic2).toBeNull();
+	});
+
+	test('should prioritize first matching rule with negation patterns', () => {
+		const warning = createWarning('font-family-no-missing-generic-family-keyword', 'error');
+
+		const customizations: RuleCustomization[] = [
+			{ rule: '!color-*', severity: 'info' },
+			{ rule: 'font-*', severity: 'warn' },
+		];
+
+		const diagnostic = warningToDiagnostic(warning, undefined, customizations);
+
+		expect(diagnostic).not.toBeNull();
+		expect(diagnostic!.severity).toBe(DiagnosticSeverity.Warning);
+	});
+
+	test('should handle complex negation patterns', () => {
+		const warning1 = createWarning('declaration-block-no-duplicate-properties', 'error');
+		const warning2 = createWarning('block-no-empty', 'error');
+		const warning3 = createWarning('color-named', 'error');
+
+		const customizations: RuleCustomization[] = [{ rule: '!*-block-*', severity: 'info' }];
+
+		const diagnostic1 = warningToDiagnostic(warning1, undefined, customizations);
+		const diagnostic2 = warningToDiagnostic(warning2, undefined, customizations);
+		const diagnostic3 = warningToDiagnostic(warning3, undefined, customizations);
+
+		// declaration-block-no-duplicate-properties matches *-block-*, so should NOT
+		// match !*-block-*.
+		expect(diagnostic1).not.toBeNull();
+		expect(diagnostic1!.severity).toBe(DiagnosticSeverity.Error);
+
+		// block-no-empty does NOT match *-block-* since there is no dash before "block",
+		// so SHOULD match !*-block-*.
+		expect(diagnostic2).not.toBeNull();
+		expect(diagnostic2!.severity).toBe(DiagnosticSeverity.Information);
+
+		// color-named does NOT match *-block-*, so SHOULD match !*-block-*.
+		expect(diagnostic3).not.toBeNull();
+		expect(diagnostic3!.severity).toBe(DiagnosticSeverity.Information);
+	});
+
+	test('should handle unknown severity override gracefully', () => {
+		const warning = createWarning('color-named', 'error');
+
+		// Create a customization with an invalid severity override.
+		const customizations: RuleCustomization[] = [
+			{
+				rule: 'color-named',
+				severity: 'unknown-severity' as unknown as RuleCustomization['severity'],
+			},
+		];
+
+		// Mock console.warn to verify it gets called.
+		const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+		const diagnostic = warningToDiagnostic(warning, undefined, customizations);
+
+		expect(consoleWarnSpy).toHaveBeenCalledWith('Unknown severity override: unknown-severity');
+		expect(diagnostic).not.toBeNull();
+		expect(diagnostic!.severity).toBe(DiagnosticSeverity.Error); // Should fallback to original severity.
+
+		consoleWarnSpy.mockRestore();
+	});
+
+	test('should apply error severity override', () => {
+		const warning = createWarning('test-rule', 'warning');
+		const customizations: RuleCustomization[] = [{ rule: 'test-rule', severity: 'error' }];
+
+		const result = warningToDiagnostic(warning, undefined, customizations);
+
+		expect(result).not.toBeNull();
+		expect(result!.severity).toBe(DiagnosticSeverity.Error);
+	});
+
+	test('should use default severity when override is "default"', () => {
+		const warningError = createWarning('color-named', 'error');
+		const warningWarn = createWarning('font-family-name', 'warning');
+		const customizations: RuleCustomization[] = [
+			{ rule: 'color-*', severity: 'info' },
+			{ rule: 'font-family-name', severity: 'default' },
+			{ rule: 'color-named', severity: 'default' },
+		];
+
+		const diagnosticError = warningToDiagnostic(warningError, undefined, customizations);
+		const diagnosticWarn = warningToDiagnostic(warningWarn, undefined, customizations);
+
+		expect(diagnosticError).not.toBeNull();
+		expect(diagnosticError!.severity).toBe(DiagnosticSeverity.Error);
+		expect(diagnosticWarn).not.toBeNull();
+		expect(diagnosticWarn!.severity).toBe(DiagnosticSeverity.Warning);
+	});
+});

--- a/src/utils/stylelint/stylelint-runner.ts
+++ b/src/utils/stylelint/stylelint-runner.ts
@@ -95,7 +95,11 @@ export class StylelintRunner {
 		}
 
 		try {
-			return processLinterResult(result.stylelint, await result.stylelint.lint(options));
+			return processLinterResult(
+				result.stylelint,
+				await result.stylelint.lint(options),
+				runnerOptions.rules?.customizations,
+			);
 		} catch (err) {
 			if (
 				err instanceof Error &&
@@ -106,6 +110,7 @@ export class StylelintRunner {
 				return processLinterResult(
 					result.stylelint,
 					await result.stylelint.lint({ ...options, config: { rules: {} } }),
+					runnerOptions.rules?.customizations,
 				);
 			}
 

--- a/src/utils/stylelint/types.ts
+++ b/src/utils/stylelint/types.ts
@@ -1,6 +1,7 @@
 import type LSP from 'vscode-languageserver-protocol';
 import type stylelint from 'stylelint';
 import type { PackageManager } from '../packages/index';
+import type { RuleCustomization } from '../../server/types';
 export type Stylelint = typeof stylelint;
 export type ConfigurationError = Error & { code: 78 };
 
@@ -51,6 +52,9 @@ export type RunnerOptions = {
 	snippet?: string[];
 	stylelintPath?: string;
 	validate?: string[];
+	rules?: {
+		customizations?: RuleCustomization[];
+	};
 };
 
 /**

--- a/src/utils/stylelint/warning-to-diagnostic.ts
+++ b/src/utils/stylelint/warning-to-diagnostic.ts
@@ -1,5 +1,108 @@
 import { Diagnostic, DiagnosticSeverity, Position, Range } from 'vscode-languageserver-types';
 import type stylelint from 'stylelint';
+import type { RuleCustomization, SeverityOverride } from '../../server/types';
+
+/**
+ * Converts a severity override value to LSP DiagnosticSeverity. Internal method
+ * that only handles direct overrides, not 'upgrade' or 'downgrade'.
+ */
+function severityOverrideToLSPSeverity(
+	override: Exclude<SeverityOverride, 'upgrade' | 'downgrade' | 'default'>,
+): DiagnosticSeverity | null {
+	switch (override) {
+		case 'error':
+			return DiagnosticSeverity.Error;
+		case 'warn':
+			return DiagnosticSeverity.Warning;
+		case 'info':
+			return DiagnosticSeverity.Information;
+		case 'off':
+			return null; // null means diagnostic should be suppressed.
+	}
+}
+
+/**
+ * Applies severity customizations to a warning.
+ */
+function applySeverityCustomization(
+	warning: stylelint.Warning,
+	ruleCustomizations?: RuleCustomization[],
+): DiagnosticSeverity | null {
+	if (!ruleCustomizations || ruleCustomizations.length === 0) {
+		// No customizations, use original severity.
+		return DiagnosticSeverity[warning.severity === 'warning' ? 'Warning' : 'Error'];
+	}
+
+	// Find matching customization. Process rules in reverse order so that
+	// subsequent rules have priority over previous ones.
+	let customization: RuleCustomization | undefined;
+
+	for (let i = ruleCustomizations.length - 1; i >= 0; i--) {
+		const custom = ruleCustomizations[i];
+		const pattern = custom.rule;
+
+		// Check for negation pattern.
+		const isNegated = pattern.startsWith('!');
+		const actualPattern = isNegated ? pattern.slice(1) : pattern;
+
+		let matches = false;
+
+		// Simple pattern matching, exact match or glob-like matching.
+		if (actualPattern === warning.rule) {
+			matches = true;
+		}
+		// Basic wildcard support for patterns like "color-*" or "*-block-*".
+		else if (actualPattern.includes('*')) {
+			const regexPattern = actualPattern
+				.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // Escape special regex chars.
+				.replace(/\\\*/g, '.*'); // Replace escaped \* with .*
+			const regex = new RegExp(`^${regexPattern}$`);
+
+			matches = regex.test(warning.rule);
+		}
+
+		// For negated patterns, invert the match result.
+		if (isNegated ? !matches : matches) {
+			customization = custom;
+			break;
+		}
+	}
+
+	if (!customization) {
+		// No matching customization, use original severity.
+		return DiagnosticSeverity[warning.severity === 'warning' ? 'Warning' : 'Error'];
+	}
+
+	const override = customization.severity;
+	const originalSeverity = DiagnosticSeverity[warning.severity === 'warning' ? 'Warning' : 'Error'];
+
+	// Handle special override types.
+	switch (override) {
+		case 'downgrade':
+			return originalSeverity === DiagnosticSeverity.Error
+				? DiagnosticSeverity.Warning
+				: DiagnosticSeverity.Information;
+		case 'upgrade':
+			// Convert warning to error, error stays error.
+			return originalSeverity === DiagnosticSeverity.Warning
+				? DiagnosticSeverity.Error
+				: originalSeverity;
+		case 'default':
+			// Use the original severity from Stylelint.
+			return originalSeverity;
+		case 'off':
+		case 'warn':
+		case 'info':
+		case 'error':
+			// Direct severity mapping.
+			return severityOverrideToLSPSeverity(override);
+		default:
+			// If we reach this branch, the override is not recognized.
+			console.warn(`Unknown severity override: ${String(override)}`);
+
+			return originalSeverity; // Fallback to original severity.
+	}
+}
 
 /**
  * Converts a Stylelint warning to an LSP Diagnostic.
@@ -38,12 +141,21 @@ import type stylelint from 'stylelint';
  * // }
  * ```
  * @param warning The warning to convert.
- * @param rules Available Stylelint rules.
+ * @param ruleMetadata Available Stylelint rules.
+ * @param ruleCustomizations Optional rule customizations for severity overrides.
  */
 export function warningToDiagnostic(
 	warning: stylelint.Warning,
 	ruleMetadata?: stylelint.LinterResult['ruleMetadata'],
-): Diagnostic {
+	ruleCustomizations?: RuleCustomization[],
+): Diagnostic | null {
+	const severity = applySeverityCustomization(warning, ruleCustomizations);
+
+	// If severity is null, the diagnostic should be suppressed.
+	if (severity === null) {
+		return null;
+	}
+
 	const start = Position.create(warning.line - 1, warning.column - 1);
 	const end =
 		typeof warning.endLine === 'number' && typeof warning.endColumn === 'number'
@@ -55,7 +167,7 @@ export function warningToDiagnostic(
 	const diagnostic = Diagnostic.create(
 		Range.create(start, end),
 		warning.text,
-		DiagnosticSeverity[warning.severity === 'warning' ? 'Warning' : 'Error'],
+		severity,
 		warning.rule,
 		'Stylelint',
 	);

--- a/test/e2e/__tests__/severity-override.ts
+++ b/test/e2e/__tests__/severity-override.ts
@@ -1,0 +1,75 @@
+import {
+	openDocument,
+	waitForDiagnostics,
+	assertDiagnostics,
+	closeAllEditors,
+	getStylelintMajorVersion,
+} from '../helpers';
+
+describe('Severity Override', () => {
+	afterEach(async () => {
+		await closeAllEditors();
+	});
+
+	it('should override rule severities according to customizations', async () => {
+		const document = await openDocument('severity-override/severity-override.css');
+		const diagnostics = await waitForDiagnostics(document);
+
+		// color-named rule should be downgraded from error to warning.
+		// color-hex-length rule should be downgraded from error to info.
+		// block-no-empty rule should be suppressed, i.e. off.
+		// comment-empty-line-before rule should be downgraded from error to info, affected by !font-* negation.
+		// custom-property-no-missing-var-function rule should be downgraded from error to warning.
+		// declaration-block-no-duplicate-properties should be upgraded from warning to error.
+		// font-family-no-missing-generic-family-keyword should keep error, not affected by !font-* negation.
+		// length-zero-no-unit should use default error severity.
+
+		assertDiagnostics(diagnostics, [
+			{
+				code: 'color-hex-length',
+				message: 'Expected "#fff" to be "#ffffff" (color-hex-length)',
+				range: [8, 9, 8, 13],
+				severity: 'info', // Overridden from error to info.
+			},
+			{
+				code: 'color-named',
+				message: 'Unexpected named color "red" (color-named)',
+				range: [4, 9, 4, 12],
+				severity: 'warning', // Overridden from error to warning.
+			},
+			// block-no-empty should be suppressed, i.e. not present in diagnostics.
+			{
+				code: 'comment-empty-line-before',
+				message: 'Expected empty line before comment (comment-empty-line-before)',
+				range: [26, 0, 26, 70],
+				severity: 'info', // Affected by !font-* negation (non-font rule gets downgraded).
+			},
+			{
+				code: 'custom-property-no-missing-var-function',
+				message:
+					'Unexpected missing var function for "--my-var" (custom-property-no-missing-var-function)',
+				range: [15, 9, 15, 17],
+				severity: 'warning', // Downgraded from error.
+			},
+			{
+				code: 'declaration-block-no-duplicate-properties',
+				message: 'Unexpected duplicate "color" (declaration-block-no-duplicate-properties)',
+				range: (await getStylelintMajorVersion()) < 16 ? [20, 2, 20, 7] : [19, 2, 19, 7],
+				severity: 'error', // Upgraded from warning.
+			},
+			{
+				code: 'font-family-no-missing-generic-family-keyword',
+				message:
+					'Unexpected missing generic font family (font-family-no-missing-generic-family-keyword)',
+				range: [24, 15, 24, 20],
+				severity: 'error', // Not affected by !font-* negation (font rules excluded).
+			},
+			{
+				code: 'length-zero-no-unit',
+				message: 'Unexpected unit (length-zero-no-unit)',
+				range: [29, 10, 29, 12],
+				severity: 'error', // Uses default severity, i.e. the original one from Stylelint.
+			},
+		]);
+	});
+});

--- a/test/e2e/workspace/severity-override/.vscode/settings.json
+++ b/test/e2e/workspace/severity-override/.vscode/settings.json
@@ -1,0 +1,33 @@
+{
+	"css.validate": false,
+	"stylelint.rules.customizations": [
+		{
+			"rule": "!font-*",
+			"severity": "info"
+		},
+		{
+			"rule": "length-zero-no-unit",
+			"severity": "default"
+		},
+		{
+			"rule": "declaration-block-*",
+			"severity": "upgrade"
+		},
+		{
+			"rule": "custom-property-no-missing-var-function",
+			"severity": "downgrade"
+		},
+		{
+			"rule": "block-no-empty",
+			"severity": "off"
+		},
+		{
+			"rule": "color-*",
+			"severity": "info"
+		},
+		{
+			"rule": "color-named",
+			"severity": "warn"
+		}
+	]
+}

--- a/test/e2e/workspace/severity-override/severity-override.css
+++ b/test/e2e/workspace/severity-override/severity-override.css
@@ -1,0 +1,31 @@
+:root { --my-var: #f1f1f1; }
+
+/* Test file for severity override functionality */
+a {
+  color: red; /* color-named violation - should be warning instead of error */
+}
+
+b {
+  color: #fff; /* color-hex-length violation - should be info instead of error */
+}
+
+c {
+} /* block-no-empty violation - should be suppressed (off) */
+
+d {
+  color: --my-var; /* custom-property-no-missing-var-function violation - should be downgraded to warning */
+}
+
+e {
+  color: #f7f7f7; /* declaration-block-no-duplicate-properties - should be upgraded to error */
+  color: #f7f7f7;
+}
+
+f {
+  font-family: Arial; /* font-family-no-missing-generic-family-keyword violation - should keep error, not affected by !font-* */
+}
+/* comment-empty-line-before violation affected by !font-* negation */
+
+g {
+  width: 0px; /* length-zero-no-unit violation - should use default severity of error */
+}

--- a/test/e2e/workspace/severity-override/stylelint.config.js
+++ b/test/e2e/workspace/severity-override/stylelint.config.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+	rules: {
+		'color-named': 'never',
+		'color-hex-length': 'long',
+		'block-no-empty': true,
+		'custom-property-no-missing-var-function': [
+			true,
+			{ severity: 'error' },
+		],
+		'declaration-block-no-duplicate-properties': [
+			true,
+			{ severity: 'warning' },
+		],
+		'font-family-no-missing-generic-family-keyword': true,
+		'comment-empty-line-before': 'always',
+		'length-zero-no-unit': true,
+	},
+};

--- a/test/e2e/workspace/workspace.code-workspace
+++ b/test/e2e/workspace/workspace.code-workspace
@@ -7,6 +7,7 @@
 		{ "path": "descriptionless-disables" },
 		{ "path": "ignore-disables" },
 		{ "path": "report-disables" },
+		{ "path": "severity-override" },
 		{ "path": "stylelint-path" },
 		{ "path": "validate" },
 	],

--- a/test/integration/jest.config.js
+++ b/test/integration/jest.config.js
@@ -9,7 +9,6 @@ const config = {
 	transform: {
 		['^.+.[jt]s$']: ['ts-jest', { tsconfig: '<rootDir>/../../tsconfig.test.json' }],
 	},
-	verbose: true,
 	setupFilesAfterEnv: ['<rootDir>/setup.ts'],
 	modulePathIgnorePatterns: [
 		'<rootDir>/../../.vscode-test',

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -7,14 +7,12 @@ const config = {
 	transform: {
 		['^.+.[jt]s$']: ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
 	},
-	verbose: true,
 	modulePathIgnorePatterns: [
 		'<rootDir>/.vscode-test',
 		'<rootDir>/test/e2e/workspace/defaults/yarn-[^/]+/stylelint',
 		'<rootDir>/test/e2e/workspace/defaults/local-stylelint/node_modules',
 	],
 	setupFilesAfterEnv: ['<rootDir>/test/unit/setup.ts'],
-	collectCoverage: true,
 	coverageThreshold: {
 		global: {
 			branches: 99,


### PR DESCRIPTION
Closes #634

- Add `stylelint.rules.customizations` setting to override rule severity levels in VS Code
- Support exact matches, wildcards, and negation patterns
- Enable downgrade/upgrade transformations and rule suppression
- Add comprehensive unit and integration tests
- Update documentation with usage examples and configuration details

Includes a drive-by refactor of the helpers.ts module for the e2e tests, which provides much nicer, detailed and useful error output when creating/modifying tests.