### PR TITLE
test: improve e2e run script

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,7 +296,7 @@
     "lint:types": "tsc -b",
     "lint:unit-tests": "ts-node --transpile-only -P tsconfig.scripts.json scripts/enforce-unit-tests-per-file.ts",
     "test": "npm run build-bundle && npm run jest -- ",
-    "test:e2e": "npm run build-bundle && vscode-test && prettier -w --parser jsonc test/e2e/workspace/workspace.code-workspace",
+    "test:e2e": "node scripts/run-e2e.js",
     "test:integration": "npm run jest -- --projects test/integration",
     "test:unit": "npm run jest -- --projects test/unit",
     "test:node-versions": "node scripts/test-node-versions.js",

--- a/scripts/run-e2e.js
+++ b/scripts/run-e2e.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const { execSync, spawn } = require('child_process');
+const process = require('process');
+
+const packageJson = require('../package.json');
+
+/**
+ * Run end-to-end tests for the VS Code extension.
+ */
+async function runE2ETest() {
+	try {
+		// Build bundle.
+		console.log('Building bundle...');
+		execSync('npm run build-bundle', { stdio: 'inherit' });
+
+		// Run vscode-test with all passed arguments.
+		console.log();
+		console.log(`> ${packageJson.name}@${packageJson.version} vscode-test`);
+		console.log(`> vscode-test ${process.argv.slice(2).join(' ')}`);
+		console.log();
+		const args = process.argv.slice(2);
+		const vscodeTest = spawn('npm', ['exec', 'vscode-test', '--', ...args], {
+			shell: process.platform === 'win32',
+			stdio: 'inherit',
+		});
+
+		const exitCode = await new Promise((resolve) => {
+			vscodeTest.on('close', resolve);
+		});
+
+		return exitCode;
+	} catch (error) {
+		console.error('Error during build or test:', error instanceof Error ? error.message : error);
+
+		return 1;
+	} finally {
+		// Always format the workspace file.
+		try {
+			console.log('Formatting workspace file...');
+			execSync(
+				'npm exec prettier -- -w --parser jsonc test/e2e/workspace/workspace.code-workspace',
+				{
+					stdio: 'inherit',
+				},
+			);
+		} catch (formatError) {
+			console.error(
+				'Error formatting workspace file:',
+				formatError instanceof Error ? formatError.message : formatError,
+			);
+		}
+	}
+}
+
+runE2ETest().then((exitCode) => {
+	// eslint-disable-next-line n/no-process-exit
+	process.exit(exitCode);
+});


### PR DESCRIPTION
Ensures that the workspace file is always formatted even if e2e tests failed, all while allowing for arguments to the test:e2e script to be passed to vscode-test, which is what is most often desired, rather than to the prettier cleanup script at the end. Uses the exit code of vscode-test as the exit code for the e2e script.