### PR TITLE
Replace deprecated `@stylelint/postcss-css-in-js` with `postcss-styled-syntax`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "winston-transport": "^4.7.1"
       },
       "devDependencies": {
-        "@stylelint/postcss-css-in-js": "^0.38.0",
         "@stylelint/prettier-config": "^3.0.0",
         "@types/jest": "^30.0.0",
         "@types/path-is-inside": "^1.0.3",
@@ -47,6 +46,7 @@
         "postcss": "^8.5.6",
         "postcss-sass": "^0.5.0",
         "postcss-scss": "^4.0.9",
+        "postcss-styled-syntax": "^0.7.1",
         "prettier": "^3.6.2",
         "stylelint": "^16.21.0",
         "stylelint-processor-glamorous": "^0.3.0",
@@ -3659,20 +3659,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
-      }
-    },
-    "node_modules/@stylelint/postcss-css-in-js": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.38.0.tgz",
-      "integrity": "sha512-XOz5CAe49kS95p5yRd+DAIWDojTjfmyAQ4bbDlXMdbZTQ5t0ThjSLvWI6JI2uiS7MFurVBkZ6zUqcimzcLTBoQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.17.9"
-      },
-      "peerDependencies": {
-        "postcss": ">=7.0.0",
-        "postcss-syntax": ">=0.36.2"
       }
     },
     "node_modules/@stylelint/prettier-config": {
@@ -12997,14 +12983,20 @@
         "node": ">=4"
       }
     },
-    "node_modules/postcss-syntax": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
-      "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
+    "node_modules/postcss-styled-syntax": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/postcss-styled-syntax/-/postcss-styled-syntax-0.7.1.tgz",
+      "integrity": "sha512-V5Iy8JztqXOKnTojdytF8IJ3zDXyVR927XftBPinJa3TnKdChGvGzUNEYlNuDtR+iqpuFkwJMgZdaJarYfGFCg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
+      "dependencies": {
+        "typescript": "^5.7.3"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
       "peerDependencies": {
-        "postcss": ">=5.0.0"
+        "postcss": "^8.5.1"
       }
     },
     "node_modules/postcss-value-parser": {

--- a/package.json
+++ b/package.json
@@ -247,7 +247,6 @@
     "winston-transport": "^4.7.1"
   },
   "devDependencies": {
-    "@stylelint/postcss-css-in-js": "^0.38.0",
     "@stylelint/prettier-config": "^3.0.0",
     "@types/jest": "^30.0.0",
     "@types/path-is-inside": "^1.0.3",
@@ -269,6 +268,7 @@
     "postcss": "^8.5.6",
     "postcss-sass": "^0.5.0",
     "postcss-scss": "^4.0.9",
+    "postcss-styled-syntax": "^0.7.1",
     "prettier": "^3.6.2",
     "stylelint": "^16.21.0",
     "stylelint-processor-glamorous": "^0.3.0",

--- a/test/e2e/workspace/code-actions/stylelint.config.js
+++ b/test/e2e/workspace/code-actions/stylelint.config.js
@@ -10,7 +10,7 @@ const config = {
 	overrides: [
 		{
 			files: ['**/*.js'],
-			customSyntax: '@stylelint/postcss-css-in-js',
+			customSyntax: 'postcss-styled-syntax',
 		},
 	],
 };

--- a/test/integration/stylelint-vscode/__snapshots__/test.ts.snap
+++ b/test/integration/stylelint-vscode/__snapshots__/test.ts.snap
@@ -155,34 +155,15 @@ exports[`StylelintRunner should support CSS-in-JS with customSyntax 1`] = `
     "codeDescription": {
       "href": "https://stylelint.io/user-guide/rules/font-weight-notation",
     },
-    "message": "Expected "bold" to be "700" (font-weight-notation)",
-    "range": {
-      "end": {
-        "character": 33,
-        "line": 2,
-      },
-      "start": {
-        "character": 29,
-        "line": 2,
-      },
-    },
-    "severity": 1,
-    "source": "Stylelint",
-  },
-  {
-    "code": "font-weight-notation",
-    "codeDescription": {
-      "href": "https://stylelint.io/user-guide/rules/font-weight-notation",
-    },
     "message": "Expected "normal" to be "400" (font-weight-notation)",
     "range": {
       "end": {
-        "character": 12,
-        "line": 4,
+        "character": 22,
+        "line": 0,
       },
       "start": {
-        "character": 6,
-        "line": 4,
+        "character": 16,
+        "line": 0,
       },
     },
     "severity": 1,
@@ -201,12 +182,12 @@ exports[`StylelintRunner with a configuration file should adhere to configuratio
     "message": "Unexpected unit (length-zero-no-unit)",
     "range": {
       "end": {
-        "character": 12,
-        "line": 3,
+        "character": 20,
+        "line": 0,
       },
       "start": {
-        "character": 10,
-        "line": 3,
+        "character": 18,
+        "line": 0,
       },
     },
     "severity": 1,

--- a/test/integration/stylelint-vscode/no-unknown.config.js
+++ b/test/integration/stylelint-vscode/no-unknown.config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-	customSyntax: '@stylelint/postcss-css-in-js',
+	customSyntax: 'postcss-styled-syntax',
 	rules: {
 		'length-zero-no-unit': true,
 		'property-no-unknown': [true, { ignoreProperties: 'what' }],

--- a/test/integration/stylelint-vscode/test.ts
+++ b/test/integration/stylelint-vscode/test.ts
@@ -115,19 +115,10 @@ describe('StylelintRunner', () => {
 		expect.assertions(1);
 		const runner = new StylelintRunner();
 		const result = await runner.lintDocument(
-			createDocument(
-				null,
-				'javascript',
-				`import glamorous from 'glamorous';
-const styled = require("styled-components");
-const A = glamorous.a({font: 'bold'});
-const B = styled.b\`
-font: normal
-\`;`,
-			),
+			createDocument(null, 'javascript', 'styled.a` font: normal `;'),
 			{
 				config: {
-					customSyntax: '@stylelint/postcss-css-in-js',
+					customSyntax: 'postcss-styled-syntax',
 					rules: { 'font-weight-notation': ['numeric'] },
 				},
 			},
@@ -419,13 +410,7 @@ describe('StylelintRunner with a configuration file', () => {
 			createDocument(
 				join(__dirname, 'has-config-file.tsx'),
 				'typescriptreact',
-				`
-const what: string = "is this";
-<a css={{
-  width: "0px",
-  what
-}} />;
-`,
+				'styled.a` width: 0px `;',
 			),
 			{ configFile: join(__dirname, 'no-unknown.config.js') },
 		);
@@ -464,7 +449,7 @@ describe('StylelintRunner with auto-fix', () => {
 		expect.assertions(1);
 		const runner = new StylelintRunner();
 		const result = await runner.lintDocument(createDocument('no-rules.js', 'javascript', '"a"'), {
-			customSyntax: '@stylelint/postcss-css-in-js',
+			customSyntax: 'postcss-styled-syntax',
 			config: {},
 			fix: true,
 		});
@@ -478,7 +463,7 @@ describe('StylelintRunner with auto-fix', () => {
 		const result = await runner.lintDocument(
 			createDocument('should-be-ignored.js', 'javascript', '"a"'),
 			{
-				customSyntax: '@stylelint/postcss-css-in-js',
+				customSyntax: 'postcss-styled-syntax',
 				config: {
 					rules: {},
 					ignoreFiles: '**/*-ignored.js',


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

This may resolve the CI failures in PR #721.

> Is there anything in the PR that needs further explanation?

This replaces the deprecated package for CSS-in-JS syntax.
The removed package may not work with the latest Stylelint 16.24.0.

Ref:
- https://www.npmjs.com/package/@stylelint/postcss-css-in-js
- https://www.npmjs.com/package/postcss-styled-syntax
