### PR TITLE
Use VS Code extension URL instead in release PR body

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -11,8 +11,7 @@ on:
 
 jobs:
   release-pr:
-    # TODO: Update to sha after the PR is merged: https://github.com/stylelint/.github/pull/78
-    uses: stylelint/.github/.github/workflows/call-release-pr.yml@add-published-url-input
+    uses: stylelint/.github/.github/workflows/call-release-pr.yml@2844df54744d5b95507c6df844b1422478dd3cc1 # 0.5.0
     with:
       new-version: ${{ github.event.inputs.new-version }}
       published-url: 'https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Requires https://github.com/stylelint/.github/pull/78

> Is there anything in the PR that needs further explanation?

See also the current release PR #746 (manually fixed the incorrect npm package URL)
