### PR TITLE
Change away from deprecated the `output` property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -298,7 +298,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.7.tgz",
       "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1015,8 +1014,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.18.tgz",
       "integrity": "sha512-EF77RqROHL+4LhMGW5NTeKqfUd/e4OOv6EDFQ/UQQiFyWuqkEKyEz0NDILxOFxWUEVdjT2GQ2cC7t12B6pESwg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.3.1",
@@ -1156,16 +1154,14 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.12.tgz",
       "integrity": "sha512-JFffQ1dDVEyJq6tCDWv0r/RqkdSnV43P2F/3jJ9rwLgdsOIXwQbXrz6QDlvQLVvNSnORH9KjDtenFTGDyzfCaA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.4.tgz",
       "integrity": "sha512-afea+0rGPDeOV9gdO06UW183Qg6wRhWVkgCFwiO3bDupAoyXRuvupbb5nUyqSTsLXIKL8u8uXQlJ9pkz07oVXw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.12",
@@ -1363,8 +1359,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
       "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.5",
@@ -1456,7 +1451,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1479,7 +1473,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4161,8 +4154,7 @@
       "version": "16.11.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
       "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -4233,7 +4225,6 @@
       "integrity": "sha512-R48VhmTJqplNyDxCyqqVkFSZIx1qX6PzwqgcXn1olLrzxcSBDlOsbtcnQuQhNtnNiJ4Xe5gREI1foajYaYU2Vg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.46.4",
@@ -4274,7 +4265,6 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -5278,7 +5268,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5804,7 +5793,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -7432,7 +7420,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7579,7 +7566,6 @@
       "integrity": "sha512-LabxXbASXVjguqL+kBHTPMf3gUeSqwH4fsrEyHTY/MCs42I/p9+ctg09SJpYiD8eGaIsP6GwYr5xW6xWS9XgZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.0.0"
       },
@@ -9504,7 +9490,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -13104,7 +13089,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13223,7 +13207,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -13296,7 +13279,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -15151,7 +15133,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15335,7 +15316,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15476,7 +15456,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/utils/documents/__tests__/__snapshots__/get-fixes.ts.snap
+++ b/src/utils/documents/__tests__/__snapshots__/get-fixes.ts.snap
@@ -1,33 +1,25 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`getFixes should return edits if Stylelint made changes 1`] = `
+exports[`getFixes should fall back to legacy output when code is unavailable 1`] = `
 [
   {
     "newText": "",
     "range": {
       "end": {
-        "character": 4,
-        "line": 2,
+        "character": 15,
+        "line": 0,
       },
       "start": {
-        "character": 3,
-        "line": 2,
+        "character": 14,
+        "line": 0,
       },
     },
   },
-  {
-    "newText": "  ",
-    "range": {
-      "end": {
-        "character": 4,
-        "line": 2,
-      },
-      "start": {
-        "character": 4,
-        "line": 2,
-      },
-    },
-  },
+]
+`;
+
+exports[`getFixes should return edits if Stylelint made changes 1`] = `
+[
   {
     "newText": "",
     "range": {
@@ -38,58 +30,6 @@ exports[`getFixes should return edits if Stylelint made changes 1`] = `
       "start": {
         "character": 3,
         "line": 5,
-      },
-    },
-  },
-  {
-    "newText": "",
-    "range": {
-      "end": {
-        "character": 4,
-        "line": 9,
-      },
-      "start": {
-        "character": 3,
-        "line": 9,
-      },
-    },
-  },
-  {
-    "newText": "  ",
-    "range": {
-      "end": {
-        "character": 4,
-        "line": 9,
-      },
-      "start": {
-        "character": 4,
-        "line": 9,
-      },
-    },
-  },
-  {
-    "newText": "",
-    "range": {
-      "end": {
-        "character": 4,
-        "line": 10,
-      },
-      "start": {
-        "character": 3,
-        "line": 10,
-      },
-    },
-  },
-  {
-    "newText": "  ",
-    "range": {
-      "end": {
-        "character": 4,
-        "line": 10,
-      },
-      "start": {
-        "character": 4,
-        "line": 10,
       },
     },
   },

--- a/src/utils/documents/get-fixes.ts
+++ b/src/utils/documents/get-fixes.ts
@@ -22,5 +22,12 @@ export async function getFixes(
 		runnerOptions,
 	);
 
-	return typeof result.output === 'string' ? createTextEdits(document, result.output) : [];
+	const fixedCode =
+		typeof result.code === 'string'
+			? result.code
+			: typeof result.output === 'string' && result.output.length > 0
+				? result.output
+				: undefined;
+
+	return typeof fixedCode === 'string' ? createTextEdits(document, fixedCode) : [];
 }

--- a/src/utils/stylelint/__tests__/__snapshots__/process-linter-result.ts.snap
+++ b/src/utils/stylelint/__tests__/__snapshots__/process-linter-result.ts.snap
@@ -56,7 +56,7 @@ exports[`processLinterResult should return diagnostics for each warning 1`] = `
 }
 `;
 
-exports[`processLinterResult should return output if given 1`] = `
+exports[`processLinterResult should include legacy output when provided 1`] = `
 {
   "diagnostics": [
     {
@@ -78,6 +78,56 @@ exports[`processLinterResult should return output if given 1`] = `
   ],
   "getWarning": [Function],
   "output": "Output",
+}
+`;
+
+exports[`processLinterResult should include report when provided 1`] = `
+{
+  "diagnostics": [
+    {
+      "code": "unit-no-unknown",
+      "message": "unit-no-unknown",
+      "range": {
+        "end": {
+          "character": 1,
+          "line": 0,
+        },
+        "start": {
+          "character": 0,
+          "line": 0,
+        },
+      },
+      "severity": 1,
+      "source": "Stylelint",
+    },
+  ],
+  "getWarning": [Function],
+  "report": "Report",
+}
+`;
+
+exports[`processLinterResult should include code when provided 1`] = `
+{
+  "code": "body {}",
+  "diagnostics": [
+    {
+      "code": "unit-no-unknown",
+      "message": "unit-no-unknown",
+      "range": {
+        "end": {
+          "character": 1,
+          "line": 0,
+        },
+        "start": {
+          "character": 0,
+          "line": 0,
+        },
+      },
+      "severity": 1,
+      "source": "Stylelint",
+    },
+  ],
+  "getWarning": [Function],
 }
 `;
 

--- a/src/utils/stylelint/__tests__/process-linter-result.ts
+++ b/src/utils/stylelint/__tests__/process-linter-result.ts
@@ -11,7 +11,7 @@ const mockStylelint = {
 
 const createMockResult = (
 	mockResults: Partial<stylelint.LintResult>[],
-	output?: string,
+	extra: Partial<stylelint.LinterResult> = {},
 ): stylelint.LinterResult => {
 	const results = mockResults.map((result) => ({
 		invalidOptionWarnings: result.invalidOptionWarnings ?? [],
@@ -19,7 +19,7 @@ const createMockResult = (
 		ignored: result.ignored ?? false,
 	}));
 
-	return (output ? { results, output } : { results }) as stylelint.LinterResult;
+	return { results, ...extra } as stylelint.LinterResult;
 };
 
 const createMockWarning = (
@@ -54,7 +54,7 @@ describe('processLinterResult', () => {
 		expect(result).toMatchSnapshot();
 	});
 
-	test('should return output if given', () => {
+	test('should include legacy output when provided', () => {
 		const result = processLinterResult(
 			mockStylelint,
 			createMockResult(
@@ -63,7 +63,39 @@ describe('processLinterResult', () => {
 						warnings: [createMockWarning('unit-no-unknown')],
 					},
 				],
-				'Output',
+				{ output: 'Output' },
+			),
+		);
+
+		expect(result).toMatchSnapshot();
+	});
+
+	test('should include report when provided', () => {
+		const result = processLinterResult(
+			mockStylelint,
+			createMockResult(
+				[
+					{
+						warnings: [createMockWarning('unit-no-unknown')],
+					},
+				],
+				{ report: 'Report' },
+			),
+		);
+
+		expect(result).toMatchSnapshot();
+	});
+
+	test('should include code when provided', () => {
+		const result = processLinterResult(
+			mockStylelint,
+			createMockResult(
+				[
+					{
+						warnings: [createMockWarning('unit-no-unknown')],
+					},
+				],
+				{ code: 'body {}' },
 			),
 		);
 

--- a/src/utils/stylelint/__tests__/stylelint-runner.ts
+++ b/src/utils/stylelint/__tests__/stylelint-runner.ts
@@ -18,6 +18,7 @@ import * as LSP from 'vscode-languageserver-protocol';
 import { StylelintResolver, ResolverOptions } from '../../packages/index';
 import { getWorkspaceFolder } from '../../documents/index';
 import { StylelintRunner } from '../stylelint-runner';
+import { snapshotLintDiagnostics } from '../../../../test/helpers/snapshots';
 import { version as stylelintVersion } from 'stylelint/package.json';
 import semver from 'semver';
 
@@ -219,7 +220,7 @@ describe('StylelintRunner', () => {
 			createMockDocument('table {', '/path/to/file.css'),
 		);
 
-		expect(results).toMatchSnapshot();
+		expect(snapshotLintDiagnostics(results)).toMatchSnapshot();
 	});
 
 	test('should return processed lint results from Stylelint with configured rules', async () => {
@@ -234,7 +235,7 @@ describe('StylelintRunner', () => {
 			{ config: { rules: { 'block-no-empty': true } } },
 		);
 
-		expect(results).toMatchSnapshot();
+		expect(snapshotLintDiagnostics(results)).toMatchSnapshot();
 	});
 
 	test('should throw errors thrown by Stylelint', async () => {

--- a/src/utils/stylelint/process-linter-result.ts
+++ b/src/utils/stylelint/process-linter-result.ts
@@ -27,8 +27,9 @@ function getDiagnosticKey(diagnostic: LSP.Diagnostic): string {
  * Processes the results of a Stylelint lint run.
  *
  * If Stylelint reported any warnings, they are converted to Diagnostics and
- * returned. If the lint results contain raw output in the `output` property, it
- * is also returned.
+ * returned. If the lint results contain raw output in the `code` property, it
+ * is also returned, along with any formatted report (`report`) or any legacy
+ * autofixed code (`output`).
  *
  * Throws an `InvalidOptionError` for any invalid option warnings reported by
  * Stylelint.
@@ -94,7 +95,19 @@ export function processLinterResult(
 
 		return warningsMap.get(key) ?? null;
 	};
-	const output = ('report' in linterResult && linterResult.report) || linterResult.output;
+	const lintDiagnostics: LintDiagnostics = { diagnostics, getWarning };
 
-	return output ? { output, diagnostics, getWarning } : { diagnostics, getWarning };
+	if ('report' in linterResult && typeof linterResult.report === 'string') {
+		lintDiagnostics.report = linterResult.report;
+	}
+
+	if ('code' in linterResult && typeof linterResult.code === 'string') {
+		lintDiagnostics.code = linterResult.code;
+	}
+
+	if (typeof linterResult.output === 'string') {
+		lintDiagnostics.output = linterResult.output;
+	}
+
+	return lintDiagnostics;
 }

--- a/src/utils/stylelint/types.ts
+++ b/src/utils/stylelint/types.ts
@@ -16,7 +16,19 @@ export type LintDiagnostics = {
 	diagnostics: LSP.Diagnostic[];
 
 	/**
-	 * Raw output from Stylelint, if any.
+	 * Formatted report returned by Stylelint, if any.
+	 */
+	report?: string;
+
+	/**
+	 * Autofixed code returned by Stylelint when linting source text with `fix`
+	 * enabled.
+	 */
+	code?: string;
+
+	/**
+	 * Raw output from Stylelint, if any. Deprecated in Stylelint 16 in favour of
+	 * `report` and `code`.
 	 */
 	output?: string;
 

--- a/test/helpers/snapshots.ts
+++ b/test/helpers/snapshots.ts
@@ -1,0 +1,14 @@
+import type { LintDiagnostics } from '../../src/utils/stylelint/types';
+
+/**
+ * Returns the subset of a Stylelint lint result that is safe to snapshot across
+ * different Stylelint versions.
+ */
+export function snapshotLintDiagnostics(
+	result: LintDiagnostics,
+): Pick<LintDiagnostics, 'diagnostics' | 'getWarning'> {
+	return {
+		diagnostics: result.diagnostics,
+		getWarning: result.getWarning,
+	};
+}

--- a/test/integration/stylelint-vscode/__snapshots__/test.ts.snap
+++ b/test/integration/stylelint-vscode/__snapshots__/test.ts.snap
@@ -220,13 +220,16 @@ exports[`StylelintRunner with auto-fix auto-fix should work if there are errors 
     },
   ],
   "getWarning": [Function],
-  "output": "
+}
+`;
+
+exports[`StylelintRunner with auto-fix auto-fix should work if there are errors that cannot be auto-fixed 2`] = `
+"
 unknown {
     color: #fff;
     background-color: #fffa;
 }
-",
-}
+"
 `;
 
 exports[`StylelintRunner with auto-fix auto-fix should work if there is syntax errors in css 1`] = `
@@ -249,9 +252,12 @@ exports[`StylelintRunner with customSyntax auto-fix should work properly if cust
 {
   "diagnostics": [],
   "getWarning": [Function],
-  "output": "a
-  color:#fff",
 }
+`;
+
+exports[`StylelintRunner with customSyntax auto-fix should work properly if customSyntax is defined 2`] = `
+"a
+  color:#fff"
 `;
 
 exports[`StylelintRunner with customSyntax should work properly if customSyntax is defined 1`] = `


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/vscode-stylelint/issues/749

> Is there anything in the PR that needs further explanation?

I figured I'd get the ball rolling. I'm very unfamiliar with the codebase and VSCode extensions in general, so I may have missed something. I've been poking around the code to try to get myself up to speed, though.

(Major change as drops support for Stylelint less than 16 (which itself is two years old). Shall we create a `v2` branch and merge into there?)
