### PR TITLE
feat: add log level configuration to extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ Though relying on a [Stylelint configuration file] in your project is highly rec
 
 Controls whether this extension is enabled or not.
 
+### `stylelint.logLevel`
+
+> Type: `"error" | "warn" | "info" | "debug"`  
+> Default: `"info"`
+
+Controls the log level used by the Stylelint extension and language server. Restart the extension host or the window after changing the setting, since it's picked up at initialization.
+
 ### `stylelint.config`
 
 > Type: `Object`  

--- a/package.json
+++ b/package.json
@@ -56,6 +56,18 @@
           "default": true,
           "description": "Control whether Stylelint is enabled or not."
         },
+        "stylelint.logLevel": {
+          "scope": "machine",
+          "type": "string",
+          "enum": [
+            "error",
+            "warn",
+            "info",
+            "debug"
+          ],
+          "default": "info",
+          "description": "Controls the log level used by the Stylelint extension and language server. Restart the extension host or the window after changing the setting, since it's picked up at initialization."
+        },
         "stylelint.codeAction.disableRuleComment": {
           "scope": "resource",
           "type": "object",

--- a/src/extension/__tests__/__snapshots__/extension.test.ts.snap
+++ b/src/extension/__tests__/__snapshots__/extension.test.ts.snap
@@ -7,6 +7,9 @@ exports[`Extension entry point > should create a language client 1`] = `
     "debug": {
       "module": "mock-path",
       "options": {
+        "env": {
+          "STYLELINT_LOG_LEVEL": "info",
+        },
         "execArgv": [
           "--nolazy",
           "--inspect=6004",
@@ -15,6 +18,11 @@ exports[`Extension entry point > should create a language client 1`] = `
     },
     "run": {
       "module": "mock-path",
+      "options": {
+        "env": {
+          "STYLELINT_LOG_LEVEL": "info",
+        },
+      },
     },
   },
   {

--- a/src/extension/__tests__/extension.test.ts
+++ b/src/extension/__tests__/extension.test.ts
@@ -59,6 +59,18 @@ const stripPaths = <T extends unknown[]>(params: T): T => {
 		if (isModuleOptions(serverOptions)) {
 			serverOptions.run.module = 'mock-path';
 			serverOptions.debug.module = 'mock-path';
+
+			if (serverOptions.run.options?.env) {
+				serverOptions.run.options.env = {
+					STYLELINT_LOG_LEVEL: serverOptions.run.options.env.STYLELINT_LOG_LEVEL,
+				};
+			}
+
+			if (serverOptions.debug.options?.env) {
+				serverOptions.debug.options.env = {
+					STYLELINT_LOG_LEVEL: serverOptions.debug.options.env.STYLELINT_LOG_LEVEL,
+				};
+			}
 		}
 	}
 
@@ -71,6 +83,9 @@ describe('Extension entry point', () => {
 
 		fileWatcherMock = vi.fn((pattern: string) => ({ pattern }));
 		mockWorkspace = {
+			getConfiguration: vi.fn(() => ({
+				get: vi.fn(() => 'info'),
+			})),
 			createFileSystemWatcher: fileWatcherMock,
 			workspaceFolders: [],
 		} as unknown as VSCodeWorkspace;

--- a/src/extension/extension.module.ts
+++ b/src/extension/extension.module.ts
@@ -15,7 +15,7 @@ export const extensionModule = module({
 	register: [
 		{
 			token: extensionTokens.serverOptions,
-			inject: [extensionTokens.serverModulePath],
+			inject: [extensionTokens.serverModulePath, extensionTokens.workspace],
 			useFactory: createServerOptions,
 		},
 		{

--- a/src/extension/start-server.ts
+++ b/src/extension/start-server.ts
@@ -4,14 +4,16 @@ import path from 'node:path';
 import process from 'node:process';
 import { createConnection, ProposedFeatures } from 'vscode-languageserver/node';
 import { StylelintLanguageServer } from '../server/index.js';
+import { parseLogLevel } from '../shared/log-level.js';
 
 const connection = createConnection(ProposedFeatures.all);
 
 const isDevelopment = process.env.NODE_ENV === 'development';
+const configuredLogLevel = parseLogLevel(process.env.STYLELINT_LOG_LEVEL);
 
 const server = new StylelintLanguageServer({
 	connection,
-	logLevel: isDevelopment ? 'debug' : 'info',
+	logLevel: configuredLogLevel ?? (isDevelopment ? 'debug' : 'info'),
 	logPath: isDevelopment ? path.join(__dirname, '../stylelint-language-server.log') : undefined,
 });
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8,10 +8,11 @@ import { platformModule } from './modules/index.js';
 import { createLanguageServerApplication } from './runtime/application.js';
 import { languageServerModule } from './server.module.js';
 import { createWinstonLoggingService, winstonToken } from './services/index.js';
+import type { LogLevel } from '../shared/log-level.js';
 
 export interface StylelintLanguageServerOptions {
 	connection: Connection;
-	logLevel?: 'error' | 'warn' | 'info' | 'debug';
+	logLevel?: LogLevel;
 	logPath?: string;
 }
 

--- a/src/server/services/infrastructure/winston-logging.service.ts
+++ b/src/server/services/infrastructure/winston-logging.service.ts
@@ -8,6 +8,7 @@ import {
 } from '../../utils/index.js';
 import { lspConnectionToken } from '../../tokens.js';
 import { type LoggingService, loggingServiceToken } from './logging.service.js';
+import type { LogLevel } from '../../../shared/log-level.js';
 
 export const winstonToken = createToken<typeof winston>('Winston');
 
@@ -15,7 +16,7 @@ export const winstonToken = createToken<typeof winston>('Winston');
  * Creates a Winston-based logging service.
  */
 export function createWinstonLoggingService(
-	level: 'error' | 'warn' | 'info' | 'debug' = 'info',
+	level: LogLevel = 'info',
 	logPath?: string,
 ): FactoryRegistration<LoggingService, [Connection, typeof winston]> {
 	return {

--- a/src/shared/log-level.ts
+++ b/src/shared/log-level.ts
@@ -1,0 +1,14 @@
+// @no-unit-test -- Type definition and simple type checking only.
+
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug';
+
+/**
+ * Parses a log level from an unknown value.
+ */
+export function parseLogLevel(value: unknown): LogLevel | undefined {
+	if (value === 'error' || value === 'warn' || value === 'info' || value === 'debug') {
+		return value;
+	}
+
+	return undefined;
+}


### PR DESCRIPTION
Makes it easier for users to get good logs if they encounter a problem with the extension, without having to mess with environment variables.

Probably a helpful thing to have as we get ready to release v2.