### PR TITLE
ci: speed up windows runs using dev drive

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,51 +30,163 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
+      - name: Setup Dev Drive (Windows)
+        if: runner.os == 'Windows'
+        id: devdrive
+        uses: samypr100/setup-dev-drive@30f0f98ae5636b2b6501e181dfb3631b9974818d # v4.0.0
+        with:
+          drive-size: 3GB
+          drive-format: ReFS
+          drive-type: Fixed
+          workspace-copy: true
+          native-dev-drive: true
+
+      - name: Resolve workspace path
+        id: workspace
+        shell: bash
+        run: |
+          workspace_path="${DEV_DRIVE_WORKSPACE:-$GITHUB_WORKSPACE}"
+          echo "path=${workspace_path}" >> "$GITHUB_OUTPUT"
+          link_path="$PWD/workspace-link"
+          rm -rf "$link_path"
+
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            link_path_win="$(pwd -W)/workspace-link"
+            link_path_win="${link_path_win//\//\\}"
+            workspace_path_win="${workspace_path//\//\\}"
+
+            MSYS2_ARG_CONV_EXCL='*' cmd /c "mklink /D "${link_path_win}" "${workspace_path_win}""
+          else
+            ln -s "$workspace_path" "$link_path"
+          fi
+
+          link_path="workspace-link"
+
+          echo "linkpath=${link_path}" >> "$GITHUB_OUTPUT"
+          echo "Determined workspace path: $workspace_path"
+          echo "Created workspace link at: $link_path"
+
+      - name: Determine Stylelint v17 ref
+        id: stylelint-ref
+        shell: bash
+        run: |
+          ref=$(git ls-remote https://github.com/stylelint/stylelint.git refs/heads/v17 | cut -f1)
+          echo "Resolved Stylelint v17 ref: ${ref:-unknown}"
+          echo "ref=${ref:-unknown}" >> "$GITHUB_OUTPUT"
+
+      - name: Hash package-lock
+        id: pkglock-hash
+        shell: bash
+        run: |
+          hash=$(sha256sum "${{ steps.workspace.outputs.linkpath }}/package-lock.json" | cut -d' ' -f1)
+          echo "Computed package-lock hash: $hash"
+          echo "hash=${hash}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore npm registry cache
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ${{ steps.workspace.outputs.path }}/.npm-cache
+          key: ${{ runner.os }}-npm-reg-${{ steps.pkglock-hash.outputs.hash }}
+          restore-keys: |
+            ${{ runner.os }}-npm-reg-
+
+      - name: Restore Stylelint tarball cache
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ${{ steps.workspace.outputs.path }}/.stylelint-cache
+          key: ${{ runner.os }}-stylelint-tar-${{ steps.stylelint-ref.outputs.ref }}
+
+      - name: Ensure Stylelint tarball
+        shell: bash
+        env:
+          STYLELINT_REF: ${{ steps.stylelint-ref.outputs.ref }}
+          STYLELINT_TARBALL_CACHE: ${{ steps.workspace.outputs.path }}/.stylelint-cache
+        run: |
+          set -euo pipefail
+          mkdir -p "$STYLELINT_TARBALL_CACHE"
+          tarball="$STYLELINT_TARBALL_CACHE/stylelint-$STYLELINT_REF.tar.gz"
+
+          if [ ! -f "$tarball" ]; then
+            echo "Downloading stylelint@$STYLELINT_REF tarball..."
+            curl -sSL "https://github.com/stylelint/stylelint/archive/${STYLELINT_REF}.tar.gz" -o "$tarball"
+          else
+            echo "Stylelint tarball already cached: $tarball"
+          fi
+          ls -lh "$tarball"
+
+      - name: Seed npm cache with Stylelint tarball
+        shell: bash
+        env:
+          STYLELINT_REF: ${{ steps.stylelint-ref.outputs.ref }}
+          STYLELINT_TARBALL_CACHE: ${{ steps.workspace.outputs.path }}/.stylelint-cache
+          NPM_CACHE_DIR: ${{ steps.workspace.outputs.path }}/.npm-cache
+        run: |
+          set -euo pipefail
+          tarball="$STYLELINT_TARBALL_CACHE/stylelint-$STYLELINT_REF.tar.gz"
+          mkdir -p "$NPM_CACHE_DIR"
+          npm cache add "$tarball" --cache "$NPM_CACHE_DIR"
+
       - name: Set up Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version-file: .nvmrc
-          cache: npm
+          node-version-file: ${{ steps.workspace.outputs.linkpath }}/.nvmrc
+          package-manager-cache: false
 
       - name: Install dependencies
+        working-directory: ${{ steps.workspace.outputs.path }}
+        env:
+          NPM_CONFIG_CACHE: ${{ steps.workspace.outputs.path }}/.npm-cache
+          NPM_CONFIG_PREFER_OFFLINE: true
         run: npm ci
 
       - name: Install Stylelint ${{ matrix.stylelint }}
+        working-directory: ${{ steps.workspace.outputs.path }}
+        env:
+          NPM_CONFIG_CACHE: ${{ steps.workspace.outputs.path }}/.npm-cache
+          NPM_CONFIG_PREFER_OFFLINE: true
         run: npm run switch-stylelint ${{ matrix.stylelint }}
 
       - name: Run unit tests
+        working-directory: ${{ steps.workspace.outputs.path }}
         run: npm run test:unit -- --coverage
 
       - name: Build and bundle
+        working-directory: ${{ steps.workspace.outputs.path }}
         run: npm run build-bundle
 
       - name: Run integration tests
+        working-directory: ${{ steps.workspace.outputs.path }}
         run: npm run test:integration -- --coverage
 
       - name: Get VS Code binary cache key
         id: vscode-cache-key
         shell: bash
+        working-directory: ${{ steps.workspace.outputs.path }}
         run: |
           if command -v shasum >/dev/null 2>&1; then
             sum=$(cat package.json | grep 'vscode["\\/]' | shasum -a 256 | cut -d' ' -f1)
           else
             sum=$(cat package.json | grep 'vscode["\\/]' | sha256sum | cut -d' ' -f1)
           fi
-          echo "cachekey=${{ runner.os }}-vscode-${sum}" >> $GITHUB_OUTPUT
+          cachekey="${{ runner.os }}-vscode-${sum}"
+          echo "Computed VS Code cache key: $cachekey"
+          echo "cachekey=${cachekey}" >> $GITHUB_OUTPUT
 
       - name: Cache VS Code binaries
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: vscode-cache
         with:
-          path: .vscode-test
+          path: ${{ steps.workspace.outputs.path }}/.vscode-test
           key: ${{ steps.vscode-cache-key.outputs.cachekey }}
 
       - name: Run end-to-end tests (Linux)
         if: ${{ runner.os == 'Linux' }}
+        working-directory: ${{ steps.workspace.outputs.path }}
         run: xvfb-run -a npm run test:e2e -- --silent
 
       - name: Run end-to-end tests (non-Linux)
         if: ${{ runner.os != 'Linux' }}
+        working-directory: ${{ steps.workspace.outputs.path }}
         run: npm run test:e2e -- --silent
 
   test-node-versions:


### PR DESCRIPTION
Disk I/O on Windows runners is notoriously slow. Using a dev drive can significantly improve run times, even with the time to set up the drive.