### PR TITLE
feat: restart workers on package updates

### DIFF
--- a/src/extension/__tests__/__snapshots__/extension.test.ts.snap
+++ b/src/extension/__tests__/__snapshots__/extension.test.ts.snap
@@ -46,6 +46,15 @@ exports[`Extension entry point > should create a language client 1`] = `
         {
           "pattern": "**/.stylelintignore",
         },
+        {
+          "pattern": "**/{package.json,package-lock.json,yarn.lock,pnpm-lock.yaml}",
+        },
+        {
+          "pattern": "**/.pnp.{cjs,js}",
+        },
+        {
+          "pattern": "**/.pnp.loader.mjs",
+        },
       ],
     },
   },

--- a/src/extension/__tests__/extension.test.ts
+++ b/src/extension/__tests__/extension.test.ts
@@ -170,12 +170,17 @@ describe('Extension entry point', () => {
 	it('should watch for changes to Stylelint configuration files', async () => {
 		await activate(mockExtensionContext, moduleOverrides);
 
-		expect(fileWatcherMock).toHaveBeenCalledTimes(3);
+		expect(fileWatcherMock).toHaveBeenCalledTimes(6);
 		expect(fileWatcherMock.mock.calls[0]).toEqual([
 			'**/.stylelintrc{,.js,.cjs,.mjs,.json,.yaml,.yml}',
 		]);
 		expect(fileWatcherMock.mock.calls[1]).toEqual(['**/stylelint.config.{js,cjs,mjs}']);
 		expect(fileWatcherMock.mock.calls[2]).toEqual(['**/.stylelintignore']);
+		expect(fileWatcherMock.mock.calls[3]).toEqual([
+			'**/{package.json,package-lock.json,yarn.lock,pnpm-lock.yaml}',
+		]);
+		expect(fileWatcherMock.mock.calls[4]).toEqual(['**/.pnp.{cjs,js}']);
+		expect(fileWatcherMock.mock.calls[5]).toEqual(['**/.pnp.loader.mjs']);
 	});
 
 	it('should register an auto-fix command', async () => {

--- a/src/extension/services/__tests__/language-client.test.ts
+++ b/src/extension/services/__tests__/language-client.test.ts
@@ -32,6 +32,9 @@ describe('language client services', () => {
 			'**/.stylelintrc{,.js,.cjs,.mjs,.json,.yaml,.yml}',
 			'**/stylelint.config.{js,cjs,mjs}',
 			'**/.stylelintignore',
+			'**/{package.json,package-lock.json,yarn.lock,pnpm-lock.yaml}',
+			'**/.pnp.{cjs,js}',
+			'**/.pnp.loader.mjs',
 		]);
 	});
 

--- a/src/extension/services/language-client.ts
+++ b/src/extension/services/language-client.ts
@@ -15,15 +15,20 @@ export type SettingMonitorFactory = (client: LanguageClient) => SettingMonitor;
  * Builds the language client options for Stylelint.
  */
 export function createClientOptions(workspace: VSCodeWorkspace): LanguageClientOptions {
+	const watchedFiles = [
+		'**/.stylelintrc{,.js,.cjs,.mjs,.json,.yaml,.yml}',
+		'**/stylelint.config.{js,cjs,mjs}',
+		'**/.stylelintignore',
+		'**/{package.json,package-lock.json,yarn.lock,pnpm-lock.yaml}',
+		'**/.pnp.{cjs,js}',
+		'**/.pnp.loader.mjs',
+	];
+
 	return {
 		documentSelector: [{ scheme: 'file' }, { scheme: 'untitled' }],
 		diagnosticCollectionName: 'Stylelint',
 		synchronize: {
-			fileEvents: [
-				workspace.createFileSystemWatcher('**/.stylelintrc{,.js,.cjs,.mjs,.json,.yaml,.yml}'),
-				workspace.createFileSystemWatcher('**/stylelint.config.{js,cjs,mjs}'),
-				workspace.createFileSystemWatcher('**/.stylelintignore'),
-			],
+			fileEvents: watchedFiles.map((pattern) => workspace.createFileSystemWatcher(pattern)),
 		},
 	};
 }

--- a/src/server/modules/lsp.module.ts
+++ b/src/server/modules/lsp.module.ts
@@ -10,6 +10,7 @@ import {
 	FormatterLspService,
 	OldStylelintWarningLspService,
 	ValidatorLspService,
+	WorkspaceActivityLspService,
 } from '../services/lsp/index.js';
 
 export const lspModule = module({
@@ -22,5 +23,6 @@ export const lspModule = module({
 		FormatterLspService,
 		OldStylelintWarningLspService,
 		ValidatorLspService,
+		WorkspaceActivityLspService,
 	],
 });

--- a/src/server/modules/stylelint-runtime.module.ts
+++ b/src/server/modules/stylelint-runtime.module.ts
@@ -12,6 +12,7 @@ import {
 	WorkerProcessService,
 	WorkerRegistryService,
 	WorkspaceStylelintService,
+	WorkerEnvironmentService,
 } from '../services/stylelint-runtime/index.js';
 
 export const stylelintRuntimeModule = module({
@@ -26,5 +27,6 @@ export const stylelintRuntimeModule = module({
 		WorkspaceStylelintService,
 		StylelintOptionsService,
 		StylelintRunnerService,
+		WorkerEnvironmentService,
 	],
 });

--- a/src/server/services/lsp/__tests__/workspace-activity.service.test.ts
+++ b/src/server/services/lsp/__tests__/workspace-activity.service.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { createContainer, module, provideTestValue } from '../../../../di/index.js';
+import { NotificationService } from '../../infrastructure/notification.service.js';
+import { StylelintRunnerService } from '../../stylelint-runtime/stylelint-runner.service.js';
+import { WorkspaceActivityLspService } from '../workspace-activity.service.js';
+
+describe('WorkspaceActivityLspService', () => {
+	test('forwards file and document events to the runner', async () => {
+		const runner = {
+			handleDocumentOpened: vi.fn(),
+			handleWatchedFilesChanged: vi.fn(),
+		} as unknown as StylelintRunnerService;
+		const notifications = {
+			on: vi.fn(() => ({ dispose() {} })),
+		} as unknown as NotificationService;
+		const container = createContainer(
+			module({
+				register: [
+					provideTestValue(StylelintRunnerService, () => runner),
+					provideTestValue(NotificationService, () => notifications),
+					WorkspaceActivityLspService,
+				],
+			}),
+		);
+		const service = container.resolve(WorkspaceActivityLspService);
+		const document = { uri: 'file:///workspace/style.css' } as never;
+
+		await service.handleDocumentOpened({ document } as never);
+		service.handleWatchedFilesChanged({
+			changes: [{ uri: 'file:///workspace/package.json', type: 1 }],
+		});
+
+		expect(runner.handleDocumentOpened).toHaveBeenCalledWith(document);
+		expect(runner.handleWatchedFilesChanged).toHaveBeenCalledWith([
+			{ uri: 'file:///workspace/package.json', type: 1 },
+		]);
+	});
+});

--- a/src/server/services/lsp/index.ts
+++ b/src/server/services/lsp/index.ts
@@ -4,3 +4,4 @@ export * from './completion.service.js';
 export * from './formatter.service.js';
 export * from './old-stylelint-warning.service.js';
 export * from './validator.service.js';
+export * from './workspace-activity.service.js';

--- a/src/server/services/lsp/workspace-activity.service.ts
+++ b/src/server/services/lsp/workspace-activity.service.ts
@@ -1,0 +1,32 @@
+import type { TextDocument } from 'vscode-languageserver-textdocument';
+import type { TextDocumentChangeEvent } from 'vscode-languageserver/node';
+import {
+	DidChangeWatchedFilesNotification,
+	type DidChangeWatchedFilesParams,
+} from 'vscode-languageserver-protocol';
+
+import { inject } from '../../../di/index.js';
+import { lspService, notification, textDocumentEvent } from '../../decorators.js';
+import { StylelintRunnerService } from '../stylelint-runtime/stylelint-runner.service.js';
+
+@lspService()
+@inject({
+	inject: [StylelintRunnerService],
+})
+export class WorkspaceActivityLspService {
+	readonly #runner: StylelintRunnerService;
+
+	constructor(runner: StylelintRunnerService) {
+		this.#runner = runner;
+	}
+
+	@textDocumentEvent('onDidOpen')
+	async handleDocumentOpened({ document }: TextDocumentChangeEvent<TextDocument>): Promise<void> {
+		await this.#runner.handleDocumentOpened(document);
+	}
+
+	@notification(DidChangeWatchedFilesNotification.type)
+	handleWatchedFilesChanged(params: DidChangeWatchedFilesParams): void {
+		this.#runner.handleWatchedFilesChanged(params.changes);
+	}
+}

--- a/src/server/services/stylelint-runtime/__tests__/worker-environment.service.test.ts
+++ b/src/server/services/stylelint-runtime/__tests__/worker-environment.service.test.ts
@@ -1,0 +1,107 @@
+import type { PathLike } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, test, vi } from 'vitest';
+
+import { createContainer, module, provideTestValue } from '../../../../di/index.js';
+import { FsPromisesModuleToken, PathModuleToken } from '../../../tokens.js';
+import { PackageRootService } from '../package-root.service.js';
+import { WorkerEnvironmentService } from '../worker-environment.service.js';
+
+type TimestampMap = Record<string, number>;
+
+type StatLike = {
+	isFile: () => boolean;
+	mtimeMs: number;
+};
+
+const createStat = (timestamps: TimestampMap) =>
+	vi.fn(async (target: PathLike): Promise<StatLike> => {
+		const key = target.toString();
+
+		if (timestamps[key] === undefined) {
+			const error = new Error('ENOENT');
+
+			(error as NodeJS.ErrnoException).code = 'ENOENT';
+			throw error;
+		}
+
+		return {
+			isFile: () => true,
+			mtimeMs: timestamps[key],
+		};
+	});
+
+const createService = (timestamps: TimestampMap, stylelintPackageRoot: string) => {
+	const stat = createStat(timestamps);
+	const fsModule = { stat } as unknown as typeof import('node:fs/promises');
+	const packageRootService = {
+		find: vi.fn(async (_startPath: string) => stylelintPackageRoot),
+	} as unknown as PackageRootService;
+
+	const container = createContainer(
+		module({
+			register: [
+				provideTestValue(PackageRootService, () => packageRootService),
+				provideTestValue(FsPromisesModuleToken, () => fsModule),
+				provideTestValue(PathModuleToken, () => path),
+				WorkerEnvironmentService,
+			],
+		}),
+	);
+
+	return { service: container.resolve(WorkerEnvironmentService), stat, packageRootService };
+};
+
+describe('WorkerEnvironmentService', () => {
+	test('encodes relevant timestamps into the environment key', async () => {
+		const workspaceRoot = path.resolve('/workspace');
+		const stylelintRoot = path.join(workspaceRoot, 'node_modules/stylelint');
+		const stylelintPath = path.join(stylelintRoot, 'index.js');
+		const { service } = createService(
+			{
+				[path.join(workspaceRoot, 'package.json')]: 100,
+				[path.join(workspaceRoot, 'package-lock.json')]: 200,
+				[stylelintPath]: 300,
+				[path.join(stylelintRoot, 'package.json')]: 400,
+			},
+			stylelintRoot,
+		);
+
+		const key = await service.createKey({
+			workerRoot: workspaceRoot,
+			stylelintPath,
+		});
+
+		expect(key).toContain('pkg:100');
+		expect(key).toContain('npmLock:200');
+		expect(key).toContain('stylelintEntry:300');
+		expect(key).toContain('stylelintPkg:400');
+	});
+
+	test('changes when manifest timestamps change', async () => {
+		const workspaceRoot = path.resolve('/workspace');
+		const stylelintRoot = path.join(workspaceRoot, 'node_modules/stylelint');
+		const stylelintPath = path.join(stylelintRoot, 'index.js');
+		const timestamps: TimestampMap = {
+			[path.join(workspaceRoot, 'package.json')]: 100,
+			[stylelintPath]: 300,
+			[path.join(stylelintRoot, 'package.json')]: 400,
+		};
+		const { service } = createService(timestamps, stylelintRoot);
+
+		const initialKey = await service.createKey({
+			workerRoot: workspaceRoot,
+			stylelintPath,
+		});
+
+		timestamps[path.join(workspaceRoot, 'package.json')] = 500;
+
+		const updatedKey = await service.createKey({
+			workerRoot: workspaceRoot,
+			stylelintPath,
+		});
+
+		expect(initialKey).not.toBe(updatedKey);
+	});
+});

--- a/src/server/services/stylelint-runtime/__tests__/workspace-stylelint.service.test.ts
+++ b/src/server/services/stylelint-runtime/__tests__/workspace-stylelint.service.test.ts
@@ -10,6 +10,7 @@ import { StylelintNotFoundError } from '../../../worker/worker-process.js';
 import { loggingServiceToken } from '../../infrastructure/logging.service.js';
 import { PackageRootCacheService } from '../package-root-cache.service.js';
 import { PnPConfigurationCacheService } from '../pnp-configuration-cache.service.js';
+import { WorkerEnvironmentService } from '../worker-environment.service.js';
 import { WorkerRegistryService } from '../worker-registry.service.js';
 import {
 	WorkspaceStylelintService,
@@ -30,6 +31,9 @@ type WorkspaceServiceMocks = {
 		disposeAll: ReturnType<typeof vi.fn>;
 		notifyWorkspaceActivity: ReturnType<typeof vi.fn>;
 		notifyFileActivity: ReturnType<typeof vi.fn>;
+	};
+	workerEnvironment: {
+		createKey: ReturnType<typeof vi.fn>;
 	};
 	packageRootCache: {
 		determineWorkerRoot: ReturnType<typeof vi.fn>;
@@ -71,6 +75,9 @@ const createService = (): WorkspaceServiceMocks => {
 		clearForWorkspace: vi.fn(),
 		clear: vi.fn(),
 	} as unknown as PnPConfigurationCacheService;
+	const workerEnvironment = {
+		createKey: vi.fn().mockResolvedValue('env-key'),
+	} as unknown as WorkerEnvironmentService;
 
 	const logger = createTestLogger();
 	const loggingService = createLoggingServiceStub(logger);
@@ -80,6 +87,7 @@ const createService = (): WorkspaceServiceMocks => {
 				provideTestValue(loggingServiceToken, () => loggingService),
 				provideTestValue(PackageRootCacheService, () => packageRootCache),
 				provideTestValue(PnPConfigurationCacheService, () => pnpCache),
+				provideTestValue(WorkerEnvironmentService, () => workerEnvironment),
 				provideTestValue(WorkerRegistryService, () => workerRegistry),
 				WorkspaceStylelintService,
 			],
@@ -91,6 +99,7 @@ const createService = (): WorkspaceServiceMocks => {
 		service,
 		worker,
 		workerRegistry: workerRegistry as unknown as WorkspaceServiceMocks['workerRegistry'],
+		workerEnvironment: workerEnvironment as unknown as WorkspaceServiceMocks['workerEnvironment'],
 		packageRootCache: packageRootCache as unknown as WorkspaceServiceMocks['packageRootCache'],
 		pnpCache: pnpCache as unknown as WorkspaceServiceMocks['pnpCache'],
 		logger,
@@ -126,6 +135,7 @@ describe('WorkspaceStylelintService', () => {
 				workspaceFolder: '/workspace',
 				workerRoot: '/workspace',
 				pnpConfig: undefined,
+				environmentKey: 'env-key',
 			},
 			expect.any(Function),
 		);

--- a/src/server/services/stylelint-runtime/index.ts
+++ b/src/server/services/stylelint-runtime/index.ts
@@ -5,6 +5,7 @@ export * from './process-runner.service.js';
 export * from './pnp-configuration-cache.service.js';
 export * from './stylelint-options.service.js';
 export * from './stylelint-runner.service.js';
+export * from './worker-environment.service.js';
 export * from './worker-process.service.js';
 export * from './worker-registry.service.js';
 export * from './workspace-stylelint.service.js';

--- a/src/server/services/stylelint-runtime/worker-environment.service.ts
+++ b/src/server/services/stylelint-runtime/worker-environment.service.ts
@@ -1,0 +1,122 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { inject } from '../../../di/index.js';
+import { normalizeFsPath } from '../../utils/index.js';
+import { FsPromisesModuleToken, PathModuleToken } from '../../tokens.js';
+import type { PnPConfiguration } from '../../types.js';
+import { PackageRootService } from './package-root.service.js';
+import { resolvePnPConfigKey } from './pnp-configuration-cache.service.js';
+
+type FsModule = Pick<typeof fs, 'stat'>;
+type PathModule = Pick<typeof path, 'dirname' | 'extname' | 'isAbsolute' | 'join' | 'resolve'>;
+
+type EnvironmentKeyInput = {
+	workerRoot: string;
+	stylelintPath?: string;
+	pnpConfig?: PnPConfiguration;
+};
+
+@inject({
+	inject: [FsPromisesModuleToken, PathModuleToken, PackageRootService],
+})
+export class WorkerEnvironmentService {
+	readonly #fs: FsModule;
+	readonly #path: PathModule;
+	readonly #packageRootService: PackageRootService;
+
+	constructor(fsModule: FsModule, pathModule: PathModule, packageRootService: PackageRootService) {
+		this.#fs = fsModule;
+		this.#path = pathModule;
+		this.#packageRootService = packageRootService;
+	}
+
+	async createKey(input: EnvironmentKeyInput): Promise<string> {
+		const normalizedRoot = this.#normalizePath(input.workerRoot);
+		const resolvedStylelintPath = this.#resolveMaybeRelative(input.stylelintPath, normalizedRoot);
+		const stylelintManifest = await this.#resolveStylelintManifest(resolvedStylelintPath);
+
+		const [
+			packageJson,
+			packageLock,
+			yarnLock,
+			pnpmLock,
+			pnpRegister,
+			pnpLoader,
+			stylelintEntry,
+			stylelintPackage,
+		] = await Promise.all([
+			this.#statStamp(this.#path.join(normalizedRoot, 'package.json')),
+			this.#statStamp(this.#path.join(normalizedRoot, 'package-lock.json')),
+			this.#statStamp(this.#path.join(normalizedRoot, 'yarn.lock')),
+			this.#statStamp(this.#path.join(normalizedRoot, 'pnpm-lock.yaml')),
+			input.pnpConfig?.registerPath ? this.#statStamp(input.pnpConfig.registerPath) : undefined,
+			input.pnpConfig?.loaderPath ? this.#statStamp(input.pnpConfig.loaderPath) : undefined,
+			resolvedStylelintPath ? this.#statStamp(resolvedStylelintPath) : undefined,
+			stylelintManifest ? this.#statStamp(stylelintManifest) : undefined,
+		]);
+
+		return [
+			`root:${normalizedRoot}`,
+			`pkg:${packageJson ?? '-'}`,
+			`npmLock:${packageLock ?? '-'}`,
+			`yarnLock:${yarnLock ?? '-'}`,
+			`pnpmLock:${pnpmLock ?? '-'}`,
+			`pnp:${resolvePnPConfigKey(input.pnpConfig)}`,
+			`pnpRegister:${pnpRegister ?? '-'}`,
+			`pnpLoader:${pnpLoader ?? '-'}`,
+			`stylelintPath:${resolvedStylelintPath ?? '-'}`,
+			`stylelintEntry:${stylelintEntry ?? '-'}`,
+			`stylelintPkg:${stylelintPackage ?? '-'}`,
+		].join('|');
+	}
+
+	async #resolveStylelintManifest(stylelintPath: string | undefined): Promise<string | undefined> {
+		if (!stylelintPath) {
+			return undefined;
+		}
+
+		const startDirectory = this.#guessDirectory(stylelintPath);
+		const packageRoot = await this.#packageRootService.find(startDirectory);
+
+		return packageRoot ? this.#path.join(packageRoot, 'package.json') : undefined;
+	}
+
+	#guessDirectory(target: string): string {
+		const extension = this.#path.extname(target);
+
+		if (extension) {
+			return this.#path.dirname(target);
+		}
+
+		return target;
+	}
+
+	async #statStamp(filePath: string): Promise<string | undefined> {
+		try {
+			const stats = await this.#fs.stat(filePath);
+
+			if (!stats.isFile()) {
+				return undefined;
+			}
+
+			return String(Math.trunc(stats.mtimeMs));
+		} catch {
+			return undefined;
+		}
+	}
+
+	#resolveMaybeRelative(target: string | undefined, base: string): string | undefined {
+		if (!target) {
+			return undefined;
+		}
+
+		return this.#path.isAbsolute(target) ? target : this.#path.resolve(base, target);
+	}
+
+	#normalizePath(value: string): string {
+		const absolute = this.#path.isAbsolute(value) ? value : this.#path.resolve(value);
+
+		return normalizeFsPath(absolute) ?? absolute;
+	}
+}

--- a/test/e2e/__tests__/stylelint-resolution.ts
+++ b/test/e2e/__tests__/stylelint-resolution.ts
@@ -1,8 +1,14 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Position, Range } from 'vscode';
+
 import {
 	openDocument,
 	waitForDiagnostics,
 	assertDiagnostics,
 	closeAllEditors,
+	getStylelintDiagnostics,
+	waitFor,
 } from '../helpers.js';
 
 describe('Stylelint resolution', () => {
@@ -37,6 +43,62 @@ describe('Stylelint resolution', () => {
 					severity: 'error',
 				},
 			]);
+		});
+
+		it('refreshes when Stylelint implementation changes', async () => {
+			const editor = await openDocument('stylelint-path/test.css');
+			const initialDiagnostics = await waitForDiagnostics(editor);
+
+			assertDiagnostics(initialDiagnostics, [
+				{
+					code: 'fake',
+					message: 'Fake result',
+					range: [0, 0, 0, 1],
+					severity: 'error',
+				},
+			]);
+
+			const stylelintPath = path.resolve(
+				__dirname,
+				'..',
+				'workspace',
+				'stylelint-path',
+				'fake-stylelint.js',
+			);
+			const originalSource = await fs.readFile(stylelintPath, 'utf8');
+			const updatedSource = originalSource.replace('Fake result', 'Fake result updated');
+
+			await fs.writeFile(stylelintPath, updatedSource, 'utf8');
+
+			try {
+				// Nudge the document to trigger revalidation without changing its final contents.
+				await editor.edit((editBuilder) => editBuilder.insert(new Position(0, 0), ' '));
+				await editor.edit((editBuilder) => editBuilder.delete(new Range(0, 0, 0, 1)));
+
+				const refreshedDiagnostics = await waitFor(
+					() => getStylelintDiagnostics(editor.document.uri),
+					(diagnostics) => diagnostics.some((diag) => diag.message === 'Fake result updated'),
+					{ timeout: 15000 },
+				);
+
+				assertDiagnostics(refreshedDiagnostics, [
+					{
+						code: 'fake',
+						message: 'Fake result updated',
+						range: [0, 0, 0, 1],
+						severity: 'error',
+					},
+				]);
+			} finally {
+				await fs.writeFile(stylelintPath, originalSource, 'utf8');
+				await editor.edit((editBuilder) => editBuilder.insert(new Position(0, 0), ' '));
+				await editor.edit((editBuilder) => editBuilder.delete(new Range(0, 0, 0, 1)));
+				await waitFor(
+					() => getStylelintDiagnostics(editor.document.uri),
+					(diagnostics) => diagnostics.some((diag) => diag.message === 'Fake result'),
+					{ timeout: 15000 },
+				);
+			}
 		});
 	});
 


### PR DESCRIPTION
Re-resolves Stylelint if the package manifest has been updated, intended to catch scenarios where the version of Stylelint is changed or updated while the worker process is running.