### PR TITLE
fix: correctly log service names

### DIFF
--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -34,6 +34,7 @@ async function bundle(): Promise<void> {
 		logLevel: 'info',
 		sourcemap: args.has('--sourcemap'),
 		minify: args.has('--minify'),
+		keepNames: true,
 	};
 
 	try {

--- a/src/server/services/infrastructure/__tests__/winston-logging.service.test.ts
+++ b/src/server/services/infrastructure/__tests__/winston-logging.service.test.ts
@@ -74,11 +74,11 @@ describe('createWinstonLoggerFactory', () => {
 			}),
 		);
 
-		const logger = loggingService.createLogger(class ExampleModule {});
+		const logger = loggingService.createLogger(class ExampleService {});
 
-		expect(logger).toEqual({ module: 'ExampleModule' });
+		expect(logger).toEqual({ service: 'ExampleService' });
 		expect(winstonStub.createLogger.mock.results[0]?.value.child).toHaveBeenCalledWith({
-			module: 'ExampleModule',
+			service: 'ExampleService',
 		});
 	});
 

--- a/src/server/services/infrastructure/winston-logging.service.ts
+++ b/src/server/services/infrastructure/winston-logging.service.ts
@@ -30,7 +30,7 @@ export function createWinstonLoggingService(
 						new ErrorFormatter(),
 						new LanguageServerFormatter({
 							connection,
-							preferredKeyOrder: ['module', 'uri', 'command'],
+							preferredKeyOrder: ['service', 'uri', 'command'],
 						}),
 					),
 				}),
@@ -62,9 +62,9 @@ export function createWinstonLoggingService(
 
 			return {
 				createLogger: (component: new () => unknown) => {
-					const moduleName = component.name || 'UnknownModule';
+					const serviceName = component.name || 'UnknownService';
 
-					return logger.child({ module: moduleName });
+					return logger.child({ service: serviceName });
 				},
 			};
 		},

--- a/src/server/worker/worker-logging.service.ts
+++ b/src/server/worker/worker-logging.service.ts
@@ -83,9 +83,9 @@ export function createWorkerLoggingService(
 
 	return {
 		createLogger: (component) => {
-			const moduleName = component.name || 'WorkerComponent';
+			const serviceName = component.name || 'UnknownService';
 
-			return logger.child({ module: moduleName });
+			return logger.child({ service: serviceName });
 		},
 	};
 }


### PR DESCRIPTION
Fixes logs that refer to different services that previously would show minified names, such as `f`, in built bundles. Also aligns logs with the terminology used in the current architecture.