### PR TITLE
fix: only serialize used fields in lint results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 2.0.0 - 2025-12-28
+## 2.0.1 - 2026-01-13
+
+- Fixed: "RangeError: Maximum call stack size exceeded" error ([#810](https://github.com/stylelint/vscode-stylelint/pull/810)).
+
+## 2.0.0 - 2026-01-12
 
 This release changes the extension's architecture to support Stylelint 17.
 

--- a/src/server/services/stylelint-runtime/__tests__/stylelint-runner.service.test.ts
+++ b/src/server/services/stylelint-runtime/__tests__/stylelint-runner.service.test.ts
@@ -11,7 +11,7 @@ import { URI } from 'vscode-uri';
 import type winston from 'winston';
 import { snapshotLintDiagnostics } from '../../../../../test/helpers/snapshots.js';
 import { createTestLogger } from '../../../../../test/helpers/test-logger.js';
-import type { StylelintResolutionResult } from '../../../stylelint/types.js';
+import type { LinterResult, StylelintResolutionResult } from '../../../stylelint/types.js';
 import {
 	StylelintNotFoundError,
 	StylelintWorkerUnavailableError,
@@ -119,20 +119,16 @@ const createRunner = (
 const createLintResult = (
 	warnings: stylelint.Warning[] = [],
 	ruleMetadata?: stylelint.LinterResult['ruleMetadata'],
-): stylelint.LinterResult =>
-	({
-		ruleMetadata,
-		results: [
-			{
-				warnings,
-				deprecations: [],
-				invalidOptionWarnings: [],
-				parseErrors: [],
-				ignored: false,
-				source: '/path/to/file.css',
-			},
-		],
-	}) as unknown as stylelint.LinterResult;
+): LinterResult => ({
+	results: [
+		{
+			warnings,
+			invalidOptionWarnings: [],
+			ignored: false,
+		},
+	],
+	ruleMetadata,
+});
 
 const createMockDocument = (code: string, uri = '/path/to/file.css'): TextDocument =>
 	({

--- a/src/server/services/stylelint-runtime/__tests__/workspace-stylelint.service.test.ts
+++ b/src/server/services/stylelint-runtime/__tests__/workspace-stylelint.service.test.ts
@@ -1,10 +1,10 @@
-import type stylelint from 'stylelint';
 import { describe, expect, test, vi } from 'vitest';
 import type winston from 'winston';
+import type * as stylelint from 'stylelint';
 
 import { createLoggingServiceStub, createTestLogger } from '../../../../../test/helpers/index.js';
 import { createContainer, module, provideTestValue } from '../../../../di/index.js';
-import type { RunnerOptions } from '../../../stylelint/types.js';
+import type { LinterResult, RunnerOptions } from '../../../stylelint/types.js';
 import type { WorkerLintResult, WorkerResolveResult } from '../../../worker/types.js';
 import { StylelintNotFoundError } from '../../../worker/worker-process.js';
 import { loggingServiceToken } from '../../infrastructure/logging.service.js';
@@ -110,7 +110,7 @@ describe('WorkspaceStylelintService', () => {
 	test('delegates lint requests to the worker registry', async () => {
 		const lintResult: WorkerLintResult = {
 			resolvedPath: '/workspace/node_modules/stylelint',
-			linterResult: { results: [] } as unknown as stylelint.LinterResult,
+			linterResult: { results: [] } satisfies LinterResult,
 		};
 		const { service, worker, workerRegistry, packageRootCache, pnpCache } = createService();
 

--- a/src/server/stylelint/process-linter-result.ts
+++ b/src/server/stylelint/process-linter-result.ts
@@ -1,9 +1,14 @@
 import * as crypto from 'crypto';
-import type { LinterResult, Warning } from 'stylelint';
+import type { Warning } from 'stylelint';
 import type LSP from 'vscode-languageserver-protocol';
 import type { Logger } from 'winston';
 import type { RuleCustomization } from '../types.js';
-import { type LintDiagnostics, type RuleMetadataSource, InvalidOptionError } from './types.js';
+import {
+	InvalidOptionError,
+	type LintDiagnostics,
+	type LinterResult,
+	type RuleMetadataSource,
+} from './types.js';
 import { warningToDiagnostic } from './warning-to-diagnostic.js';
 
 /**

--- a/src/server/stylelint/types.ts
+++ b/src/server/stylelint/types.ts
@@ -11,6 +11,26 @@ export type RuleMetadataSource = {
 };
 
 /**
+ * Minimal subset of a Stylelint lint result required by the language server.
+ */
+export type LintResult = {
+	warnings: stylelint.Warning[];
+	invalidOptionWarnings: stylelint.LintResult['invalidOptionWarnings'];
+	ignored?: boolean;
+};
+
+/**
+ * Minimal subset of a Stylelint linter result required by the language server.
+ */
+export type LinterResult = {
+	results: LintResult[];
+	report?: string;
+	code?: string;
+	output?: string;
+	ruleMetadata?: stylelint.LinterResult['ruleMetadata'];
+};
+
+/**
  * Diagnostics for a lint run.
  */
 export type LintDiagnostics = {

--- a/src/server/worker/types.ts
+++ b/src/server/worker/types.ts
@@ -1,6 +1,6 @@
 import type stylelint from 'stylelint';
 
-import type { RuleMetadataSnapshot, RunnerOptions } from '../stylelint/types.js';
+import type { LinterResult, RuleMetadataSnapshot, RunnerOptions } from '../stylelint/types.js';
 
 export const stylelintNotFoundError = 'STYLELINT_NOT_FOUND';
 
@@ -18,7 +18,7 @@ export type WorkerResolvePayload = {
 
 export type WorkerLintResult = {
 	resolvedPath: string;
-	linterResult: stylelint.LinterResult;
+	linterResult: LinterResult;
 	ruleMetadata?: RuleMetadataSnapshot;
 };
 

--- a/test/e2e/__tests__/postcss-html.test.ts
+++ b/test/e2e/__tests__/postcss-html.test.ts
@@ -1,0 +1,22 @@
+import * as assert from 'node:assert/strict';
+
+import { assertDiagnostic, closeAllEditors, openDocument, waitForDiagnostics } from '../helpers.js';
+
+describe('postcss-html', () => {
+	afterEach(async () => {
+		await closeAllEditors();
+	});
+
+	it('lints a Vue file', async () => {
+		const { document } = await openDocument('postcss-html/test.vue');
+		const diagnostics = await waitForDiagnostics(document);
+
+		assert.equal(diagnostics.length, 1);
+		assertDiagnostic(diagnostics[0], {
+			code: 'color-no-hex',
+			message: 'Unexpected hex color "#000" (color-no-hex)',
+			range: [6, 9, 6, 13],
+			severity: 'error',
+		});
+	});
+});

--- a/test/e2e/workspace/postcss-html/.vscode/settings.json
+++ b/test/e2e/workspace/postcss-html/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"stylelint.validate": ["vue", "plaintext", "html"]
+}

--- a/test/e2e/workspace/postcss-html/stylelint.config.js
+++ b/test/e2e/workspace/postcss-html/stylelint.config.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/** @type {import('stylelint').Config} */
+module.exports = {
+	customSyntax: require.resolve('postcss-html'),
+	rules: {
+		'color-no-hex': true,
+	},
+};

--- a/test/e2e/workspace/postcss-html/test.vue
+++ b/test/e2e/workspace/postcss-html/test.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="app">Hello</div>
+</template>
+
+<style>
+.app {
+  color: #000;
+}
+</style>

--- a/test/e2e/workspace/workspace.code-workspace
+++ b/test/e2e/workspace/workspace.code-workspace
@@ -14,6 +14,7 @@
 		{ "path": "prefer-esm" },
 		{ "path": "worker-crash" },
 		{ "path": "ignore-cwd" },
+		{ "path": "postcss-html" },
 	],
 	"settings": {},
 }

--- a/test/integration/server/__tests__/language-client.test.ts
+++ b/test/integration/server/__tests__/language-client.test.ts
@@ -406,6 +406,29 @@ describe('Language server', () => {
 		await closeDocument(client, documentUri);
 	});
 
+	it('continues linting when a custom stylelintPath returns recursive data', async () => {
+		stylelintSettings = {
+			stylelintPath: path.join(workspaceRoot, 'fake-stylelint-recursive.js'),
+			validate: ['css'],
+		};
+
+		await client.sendNotification(LSP.DidChangeConfigurationNotification.type, {
+			settings: { stylelint: stylelintSettings },
+		});
+
+		const documentUri = pathToFileURL(path.join(workspaceRoot, 'recursive.css')).toString();
+		const { diagnostics } = await openDocumentAndWaitForDiagnostics(
+			client,
+			documentUri,
+			'css',
+			'a { color: #000; }',
+		);
+
+		expect(diagnostics.diagnostics[0]?.code).toBe('fake-recursive');
+
+		await closeDocument(client, documentUri);
+	});
+
 	testOnVersion('<15', 'formats documents according to formatting options', async () => {
 		stylelintSettings = { validate: ['css'] };
 

--- a/test/integration/stylelint-vscode/fake-stylelint-recursive.js
+++ b/test/integration/stylelint-vscode/fake-stylelint-recursive.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const recursive = {};
+
+recursive.self = recursive;
+
+module.exports = {
+	lint() {
+		return {
+			results: [
+				{
+					warnings: [
+						{
+							line: 1,
+							column: 1,
+							rule: 'fake-recursive',
+							text: 'Recursive payload should not crash',
+							severity: 'error',
+						},
+					],
+					invalidOptionWarnings: [],
+					// Intentional recursive shape that would fail JSON serialization if forwarded directly.
+					recursive,
+				},
+			],
+		};
+	},
+};


### PR DESCRIPTION
Fixes #809.

Sidestep failed lints due to unserializable recursive objects being tacked onto lint results by certain plugins/custom syntaxes.