### PR TITLE
fix: formatting with custom syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed: formatting with Stylelint 14 and 15 when using custom syntaxes ([#813](https://github.com/stylelint/vscode-stylelint/pull/813)).
+
 ## 2.0.1 - 2026-01-13
 
 - Fixed: "RangeError: Maximum call stack size exceeded" error ([#810](https://github.com/stylelint/vscode-stylelint/pull/810)).

--- a/src/server/services/documents/document-fixes.service.ts
+++ b/src/server/services/documents/document-fixes.service.ts
@@ -3,6 +3,7 @@ import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { TextEdit } from 'vscode-languageserver-types';
 import type winston from 'winston';
 import { createToken, inject } from '../../../di/index.js';
+import type { RunnerOptions } from '../../stylelint/types.js';
 import { getFixes } from '../../utils/index.js';
 import { type LoggingService, loggingServiceToken } from '../infrastructure/logging.service.js';
 import { StylelintRunnerService } from '../stylelint-runtime/stylelint-runner.service.js';
@@ -46,6 +47,21 @@ export class DocumentFixesService {
 			this.#logger?.error('Error getting fixes', { uri: document.uri, error });
 
 			return [];
+		}
+	}
+
+	async resolveConfig(document: TextDocument): Promise<stylelint.Config | undefined> {
+		try {
+			const runnerOptions = await this.#options.getOptions(document.uri);
+			const config = await this.#runner.resolveConfig(document, runnerOptions as RunnerOptions);
+
+			this.#logger?.debug('Config resolved', { uri: document.uri, hasConfig: Boolean(config) });
+
+			return config;
+		} catch (error) {
+			this.#logger?.error('Error resolving config', { uri: document.uri, error });
+
+			return undefined;
 		}
 	}
 }

--- a/src/server/worker/types.ts
+++ b/src/server/worker/types.ts
@@ -16,6 +16,12 @@ export type WorkerResolvePayload = {
 	runnerOptions?: RunnerOptions;
 };
 
+export type WorkerResolveConfigPayload = {
+	filePath: string;
+	stylelintPath?: string;
+	runnerOptions?: RunnerOptions;
+};
+
 export type WorkerLintResult = {
 	resolvedPath: string;
 	linterResult: LinterResult;
@@ -28,6 +34,11 @@ export type WorkerResolveResult = {
 	version?: string;
 };
 
+export type WorkerResolveConfigResult = {
+	resolvedPath: string;
+	config: stylelint.Config | undefined;
+};
+
 export type WorkerRequest =
 	| {
 			id: string;
@@ -38,6 +49,11 @@ export type WorkerRequest =
 			id: string;
 			type: 'resolve';
 			payload: WorkerResolvePayload;
+	  }
+	| {
+			id: string;
+			type: 'resolveConfig';
+			payload: WorkerResolveConfigPayload;
 	  }
 	| {
 			id: string;
@@ -55,7 +71,7 @@ export type WorkerResponse =
 	| {
 			id: string;
 			success: true;
-			result?: WorkerLintResult | WorkerResolveResult | undefined;
+			result?: WorkerLintResult | WorkerResolveResult | WorkerResolveConfigResult | undefined;
 	  }
 	| {
 			id: string;

--- a/src/server/worker/worker-process.ts
+++ b/src/server/worker/worker-process.ts
@@ -14,6 +14,8 @@ import {
 	type WorkerLintPayload,
 	type WorkerLintResult,
 	type WorkerRequest,
+	type WorkerResolveConfigPayload,
+	type WorkerResolveConfigResult,
 	type WorkerResolvePayload,
 	type WorkerResolveResult,
 	type WorkerResponse,
@@ -173,6 +175,12 @@ export class StylelintWorkerProcess {
 		return result;
 	}
 
+	async resolveConfig(payload: WorkerResolveConfigPayload): Promise<WorkerResolveConfigResult> {
+		const result = (await this.#sendRequest('resolveConfig', payload)) as WorkerResolveConfigResult;
+
+		return result;
+	}
+
 	dispose(): void {
 		if (this.#disposed) {
 			return;
@@ -235,7 +243,9 @@ export class StylelintWorkerProcess {
 				id,
 				type,
 
-				payload: (payload ?? {}) as WorkerLintPayload & WorkerResolvePayload,
+				payload: (payload ?? {}) as WorkerLintPayload &
+					WorkerResolvePayload &
+					WorkerResolveConfigPayload,
 			};
 
 			this.#child.send(request);

--- a/test/e2e/__tests__/format.test.ts
+++ b/test/e2e/__tests__/format.test.ts
@@ -35,4 +35,25 @@ describe('Document formatting', () => {
 `,
 		);
 	});
+
+	pre16It('should format document with customSyntax from stylelint config', async () => {
+		const editor = await openDocument('format-custom-syntax/test.scss');
+
+		editor.options.tabSize = 2;
+		editor.options.insertSpaces = true;
+
+		await sleep(1000); // HACK: Prevent flaky test.
+		await commands.executeCommand('editor.action.formatDocument');
+
+		assert.equal(
+			editor.document.getText(),
+			`/* prettier-ignore */
+$primary-color: #fff;
+
+.foo {
+  color: $primary-color;
+}
+`,
+		);
+	});
 });

--- a/test/e2e/workspace/format-custom-syntax/.vscode/settings.json
+++ b/test/e2e/workspace/format-custom-syntax/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"[scss]": {
+		"editor.defaultFormatter": "stylelint.vscode-stylelint"
+	},
+	"stylelint.validate": ["scss"]
+}

--- a/test/e2e/workspace/format-custom-syntax/stylelint.config.js
+++ b/test/e2e/workspace/format-custom-syntax/stylelint.config.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+	overrides: [
+		{
+			files: ['*.scss', '**/*.scss'],
+			customSyntax: 'postcss-scss',
+		},
+	],
+	rules: {
+		// Stylistic rules for formatting available in Stylelint <16
+		indentation: 2,
+		'no-eol-whitespace': true,
+	},
+};

--- a/test/e2e/workspace/format-custom-syntax/test.scss
+++ b/test/e2e/workspace/format-custom-syntax/test.scss
@@ -1,0 +1,6 @@
+/* prettier-ignore */
+$primary-color: #fff;
+
+.foo {
+		color: $primary-color;
+}

--- a/test/e2e/workspace/workspace.code-workspace
+++ b/test/e2e/workspace/workspace.code-workspace
@@ -5,6 +5,7 @@
 		{ "path": "custom-syntax" },
 		{ "path": "defaults" },
 		{ "path": "descriptionless-disables" },
+		{ "path": "format-custom-syntax" },
 		{ "path": "ignore-disables" },
 		{ "path": "no-rules-configured" },
 		{ "path": "report-disables" },

--- a/test/helpers/stubs/document-fixes-service.ts
+++ b/test/helpers/stubs/document-fixes-service.ts
@@ -1,25 +1,39 @@
+import type stylelint from 'stylelint';
 import * as LSP from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import type { DocumentFixesService } from '../../../src/server/services/index.js';
 
-export type DocumentFixesServiceStub = Pick<DocumentFixesService, 'getFixes'> & {
+export type DocumentFixesServiceStub = Pick<DocumentFixesService, 'getFixes' | 'resolveConfig'> & {
 	setFixes(uri: string, edits: LSP.TextEdit[]): void;
+	setResolvedConfig(uri: string, config: stylelint.Config | undefined): void;
 	calls: Array<{ document: TextDocument; options?: unknown }>;
+	resolveConfigCalls: Array<{ document: TextDocument }>;
 };
 
 export function createDocumentFixesServiceStub(): DocumentFixesServiceStub {
 	const fixes = new Map<string, LSP.TextEdit[]>();
+	const resolvedConfigs = new Map<string, stylelint.Config | undefined>();
 	const calls: DocumentFixesServiceStub['calls'] = [];
+	const resolveConfigCalls: DocumentFixesServiceStub['resolveConfigCalls'] = [];
 
 	return {
 		calls,
+		resolveConfigCalls,
 		setFixes: (uri: string, edits: LSP.TextEdit[]) => {
 			fixes.set(uri, edits);
+		},
+		setResolvedConfig: (uri: string, config: stylelint.Config | undefined) => {
+			resolvedConfigs.set(uri, config);
 		},
 		async getFixes(document: TextDocument, options?: unknown) {
 			calls.push({ document, options });
 
 			return fixes.get(document.uri) ?? [];
+		},
+		async resolveConfig(document: TextDocument) {
+			resolveConfigCalls.push({ document });
+
+			return resolvedConfigs.get(document.uri);
 		},
 	};
 }

--- a/test/integration/stylelint-vscode/formatting.css
+++ b/test/integration/stylelint-vscode/formatting.css
@@ -1,0 +1,1 @@
+/* Placeholder file for formatting integration tests */


### PR DESCRIPTION
Fixes #328

Fetch config for given file and apply custom syntax setting, if present, to support formatting non-CSS files with Stylelint 14 and 15.