### PR TITLE
feat: improve UX when trying to format with 16+

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The official [Visual Studio Code](https://code.visualstudio.com/) extension for 
 - [Usage](#usage)
   - [Commands](#commands)
   - [Actions](#actions)
+  - [Document Formatting](#document-formatting)
   - [Extension Settings](#extension-settings)
 - [Migrating](#migrating)
   - [From vscode-stylelint 1.x](#from-vscode-stylelint-1x)
@@ -122,6 +123,27 @@ You can also selectively enable and disable specific languages using VS Code's l
     }
   }
 ```
+
+### Document Formatting
+
+This extension registers as a document formatter for validated languages. However, **document formatting is only available with Stylelint 14 and 15**. Starting with Stylelint 16, [stylistic rules were removed](https://stylelint.io/migration-guide/to-16#removed-deprecated-stylistic-rules) from Stylelint and moved to the [@stylistic/stylelint-plugin](https://www.npmjs.com/package/@stylistic/stylelint-plugin) package.
+
+When using Stylelint 14 or 15, you can format a document by running the `Format Document` command from the command palette or by using the keyboard shortcut (by default, `Shift`+`Alt`+`F` on Windows/Linux and `Shift`+`Option`+`F` on macOS).
+
+This will **only** apply the formatting configuration from your editor settings by mapping them to the stylistic rules in Stylelint. It will not apply any fixes for other lint warnings or errors.
+
+**If you're using Stylelint 16 or later** and try to format a document, you'll see a message explaining that formatting isn't available. For auto-fixing lint issues, you have two options:
+
+1. Run the `Fix all auto-fixable problems` command from the command palette.
+2. Configure `editor.codeActionsOnSave` in your settings to automatically fix issues on save:
+
+```json
+  "editor.codeActionsOnSave": {
+    "source.fixAll.stylelint": "explicit"
+  }
+```
+
+If you need stylistic formatting with Stylelint 16+, consider using a dedicated code formatter like [Prettier](https://prettier.io/) alongside Stylelint for linting.
 
 ### Extension Settings
 

--- a/test/e2e/__tests__/format.test.ts
+++ b/test/e2e/__tests__/format.test.ts
@@ -3,7 +3,7 @@ import * as semver from 'semver';
 
 import { commands } from 'vscode';
 
-import { openDocument, closeAllEditors, setupSettings, sleep } from '../helpers.js';
+import { openDocument, closeAllEditors, setupSettings, sleep, itOnVersion } from '../helpers.js';
 
 describe('Document formatting', () => {
 	setupSettings({ '[css]': { 'editor.defaultFormatter': 'stylelint.vscode-stylelint' } });
@@ -34,5 +34,18 @@ describe('Document formatting', () => {
 }
 `,
 		);
+	});
+
+	itOnVersion('>=16', 'should not modify document with Stylelint 16+', async () => {
+		const editor = await openDocument('defaults/format.css');
+		const originalText = editor.document.getText();
+
+		editor.options.tabSize = 4;
+		editor.options.insertSpaces = false;
+
+		await sleep(1000); // HACK: Prevent flaky test.
+		await commands.executeCommand('editor.action.formatDocument');
+
+		assert.equal(editor.document.getText(), originalText);
 	});
 });


### PR DESCRIPTION
Show a message to users when they try to format documents with Stylelint 16 or above.

Formatting is only supported with Stylelint 14 and 15. However, there is no feasible and reliable way to register a document formatter only for documents that will be linted with those versions of Stylelint. This leads to behaviour where users are surprised that nothing happens when they run the format document command.

To avoid this confusion, this change provides clear and concise messaging to the user when they try to do so. The message presented to the user links to a new section in the readme that describes the formatting behaviour in simple terms, and provides guidance on how to use and configure the auto-fix functionality, which is what most users really want.