### PR TITLE
Change `ubuntu-latest` to `ubuntu-slim` runner for cost efficiency

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -138,7 +138,7 @@ jobs:
         run: npm run test:e2e -- --silent
 
   test-node-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This PR switches to `ubuntu-slim` GitHub Actions runner for short-running jobs, except for heavy testing.

Ref https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners

For details, see also https://github.com/stylelint/.github/pull/89

