### PR TITLE
feat: prompt to restart host when editing logLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added: notification prompting to restart the extension host when `stylelint.logLevel` setting changes ([#849](https://github.com/stylelint/vscode-stylelint/pull/849)).
 - Added: warning when `stylelint.config` is an empty object ([#846](https://github.com/stylelint/vscode-stylelint/pull/846)).
 
 ## 2.0.2 - 2026-02-06

--- a/src/extension/__tests__/extension.test.ts
+++ b/src/extension/__tests__/extension.test.ts
@@ -88,6 +88,7 @@ describe('Extension entry point', () => {
 			})),
 			createFileSystemWatcher: fileWatcherMock,
 			workspaceFolders: [],
+			onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
 		} as unknown as VSCodeWorkspace;
 
 		registerCommandMock = vi.fn();

--- a/src/extension/extension-runtime.service.ts
+++ b/src/extension/extension-runtime.service.ts
@@ -41,6 +41,8 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 	readonly #notificationDisposables: Disposable[] = [];
 	readonly #commandDisposables: Disposable[] = [];
 	#settingMonitorDisposable?: Disposable;
+	#configChangeDisposable?: Disposable;
+	#initialLogLevel: string | undefined;
 
 	constructor(
 		languageClient: LanguageClient,
@@ -69,6 +71,7 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 
 		await this.#resetWorkspaceState();
 		this.#registerCommands();
+		this.#registerConfigurationChangeHandler();
 
 		this.#settingMonitorDisposable = this.#createSettingMonitor(this.#client).start();
 		this.#context.subscriptions.push(this.#settingMonitorDisposable);
@@ -78,6 +81,16 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 		await this.#stopClient();
 		this.#disposeNotifications();
 		this.#disposeCommands();
+
+		if (this.#configChangeDisposable) {
+			try {
+				this.#configChangeDisposable.dispose();
+			} catch {
+				// Best-effort cleanup.
+			}
+
+			this.#configChangeDisposable = undefined;
+		}
 
 		if (this.#settingMonitorDisposable) {
 			try {
@@ -176,6 +189,36 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 
 		this.#registerDisposable(executeAutofixDisposable);
 		this.#registerDisposable(restartDisposable);
+	}
+
+	#registerConfigurationChangeHandler(): void {
+		this.#initialLogLevel = this.#workspace.getConfiguration('stylelint').get<string>('logLevel');
+
+		this.#configChangeDisposable = this.#workspace.onDidChangeConfiguration(async (event) => {
+			if (!event.affectsConfiguration('stylelint.logLevel')) {
+				return;
+			}
+
+			const newLogLevel = this.#workspace.getConfiguration('stylelint').get<string>('logLevel');
+
+			if (newLogLevel === this.#initialLogLevel) {
+				return;
+			}
+
+			this.#initialLogLevel = newLogLevel;
+
+			const restartAction = 'Restart Extension Host';
+			const result = await this.#window.showInformationMessage(
+				'The log level setting has changed. Restart the extension host for the change to take effect.',
+				restartAction,
+			);
+
+			if (result === restartAction) {
+				await this.#commands.executeCommand('workbench.action.restartExtensionHost');
+			}
+		});
+
+		this.#context.subscriptions.push(this.#configChangeDisposable);
 	}
 
 	async #resetWorkspaceState(): Promise<void> {


### PR DESCRIPTION
When the stylelint.logLevel setting is changed, the user does not get immediate feedback that indicates that they need to restart the extension host before the change takes effect.

This change prompts the user whenever the setting is changed, along with a button that restarts the extension host when clicked. This should guide users to follow the necessary steps rather than just hoping that they've read the fine print.