### PR TITLE
feat: add runtime and execArgv settings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -130,7 +130,7 @@ The rest of the extension code never imports `vscode` directly and depends on th
 
 ### 3.3 Extension module: language client, public API, runtime service
 
-`src/extension/extension.module.ts` composes the extension's own services on top of the platform module. It registers providers for `extensionTokens.serverOptions` and `extensionTokens.clientOptions`, created by `createServerOptions(...)` and `createClientOptions(...)` in `src/extension/services/language-client.ts`. It also provides `extensionTokens.settingMonitorFactory`, which knows how to create a `SettingMonitor` from the language client module, and `extensionTokens.languageClient`, created by `createLanguageClient(...)` using the language client module, server options, and client options. The module wires up `extensionTokens.publicApi` via `createPublicApi(...)` and registers `ExtensionRuntimeService` itself as a runtime service.
+`src/extension/extension.module.ts` composes the extension's own services on top of the platform module. It registers providers for `extensionTokens.clientOptions`, created by `createClientOptions(...)` in `src/extension/services/language-client.ts`, plus `ServerOptionsService` and `LanguageClientService` as class providers. The module wires up `extensionTokens.publicApi` via `createPublicApi(...)` and registers `ExtensionRuntimeService` itself as a runtime service.
 
 All of these are normal DI providers: the module is just a declarative description of how to build them.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-- Fixed: `url` reported on Stylelint warnings not being used for documentation links ([#852](https://github.com/stylelint/vscode-stylelint/issues/852)).
-- Added: `stylelint.ignorePath` setting to specify a custom ignore file ([#851](https://github.com/stylelint/vscode-stylelint/issues/851)).
-- Added: `stylelint.run` setting to control when the linter runs ([#848](https://github.com/stylelint/vscode-stylelint/issues/848)).
+- Added: `stylelint.runtime` and `stylelint.execArgv` settings to customize the Node.js binary and exec arguments used by the language server ([#854](https://github.com/stylelint/vscode-stylelint/pull/854)).
+- Fixed: `url` reported on Stylelint warnings not being used for documentation links ([#852](https://github.com/stylelint/vscode-stylelint/pull/852)).
+- Added: `stylelint.ignorePath` setting to specify a custom ignore file ([#851](https://github.com/stylelint/vscode-stylelint/pull/851)).
+- Added: `stylelint.run` setting to control when the linter runs ([#848](https://github.com/stylelint/vscode-stylelint/pull/848)).
 - Added: notification prompting to restart the extension host when `stylelint.logLevel` setting changes ([#849](https://github.com/stylelint/vscode-stylelint/pull/849)).
 - Added: warning when `stylelint.config` is an empty object ([#846](https://github.com/stylelint/vscode-stylelint/pull/846)).
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,36 @@ Controls when the linter runs.
 
 Controls the log level used by the Stylelint extension and language server. Restart the extension host or the window after changing the setting, since it's picked up at initialization.
 
+#### `stylelint.runtime`
+
+> Type: `string | null`  
+> Default: `null`
+
+The location of the node binary to run Stylelint under. By default, the extension uses the Node.js runtime bundled with VS Code. Set this to use a different Node.js version on your system.
+
+For example:
+
+```json
+  "stylelint.runtime": "/usr/local/bin/node"
+```
+
+Changing this setting requires a server restart to take effect.
+
+#### `stylelint.execArgv`
+
+> Type: `string[] | null`  
+> Default: `null`
+
+Additional exec argv arguments passed to the Node.js runtime.
+
+For example:
+
+```json
+  "stylelint.execArgv": ["--max_old_space_size=8192"]
+```
+
+Changing this setting requires a server restart to take effect.
+
 #### `stylelint.validate`
 
 > Type: `string[]`  

--- a/package.json
+++ b/package.json
@@ -78,6 +78,31 @@
           "default": "info",
           "description": "Controls the log level used by the Stylelint extension and language server. Restart the extension host or the window after changing the setting, since it's picked up at initialization."
         },
+        "stylelint.runtime": {
+          "scope": "machine-overridable",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "markdownDescription": "The location of the node binary to run Stylelint under."
+        },
+        "stylelint.execArgv": {
+          "scope": "machine-overridable",
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "markdownDescription": "Additional exec argv arguments passed to the Node.js runtime."
+        },
         "stylelint.codeAction.disableRuleComment": {
           "scope": "resource",
           "type": "object",

--- a/src/extension/__tests__/__snapshots__/extension.test.ts.snap
+++ b/src/extension/__tests__/__snapshots__/extension.test.ts.snap
@@ -35,6 +35,11 @@ exports[`Extension entry point > should create a language client 1`] = `
         "scheme": "untitled",
       },
     ],
+    "outputChannel": {
+      "append": [MockFunction],
+      "appendLine": [MockFunction],
+      "dispose": [MockFunction],
+    },
     "synchronize": {
       "fileEvents": [
         {

--- a/src/extension/__tests__/extension.test.ts
+++ b/src/extension/__tests__/extension.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ExtensionContext, TextEditor } from 'vscode';
-import type { LanguageClient, NodeModule, SettingMonitor } from 'vscode-languageclient/node';
+import type { LanguageClient, NodeModule } from 'vscode-languageclient/node';
 import {
 	DidRegisterDocumentFormattingEditProviderNotificationParams,
 	Notification,
@@ -28,9 +28,9 @@ const mockTextEditor = {
 
 const start = vi.fn();
 const stop = vi.fn();
+const dispose = vi.fn();
 const onNotification = vi.fn();
 const sendRequest = vi.fn();
-const settingMonitorStart = vi.fn();
 
 const mockExtensionContext = {
 	subscriptions: [],
@@ -40,7 +40,6 @@ let mockWorkspace: VSCodeWorkspace;
 let mockCommands: VSCodeCommands;
 let mockWindow: VSCodeWindow;
 let mockLanguageClient: ReturnType<typeof vi.fn>;
-let mockSettingMonitor: ReturnType<typeof vi.fn>;
 let languageClientInstance: LanguageClient;
 let moduleOverrides: Iterable<ExtensionOverrideEntry>;
 let registerCommandMock: ReturnType<typeof vi.fn>;
@@ -84,7 +83,13 @@ describe('Extension entry point', () => {
 		fileWatcherMock = vi.fn((pattern: string) => ({ pattern }));
 		mockWorkspace = {
 			getConfiguration: vi.fn(() => ({
-				get: vi.fn(() => 'info'),
+				get: vi.fn((key: string, defaultValue?: unknown) => {
+					if (key === 'logLevel') {
+						return 'info';
+					}
+
+					return defaultValue;
+				}),
 			})),
 			createFileSystemWatcher: fileWatcherMock,
 			workspaceFolders: [],
@@ -99,6 +104,11 @@ describe('Extension entry point', () => {
 		showErrorMessageMock = vi.fn(async () => undefined);
 		mockWindow = {
 			activeTextEditor: undefined,
+			createOutputChannel: vi.fn(() => ({
+				append: vi.fn(),
+				appendLine: vi.fn(),
+				dispose: vi.fn(),
+			})),
 			showErrorMessage: showErrorMessageMock,
 			showInformationMessage: vi.fn(),
 			showWarningMessage: vi.fn(),
@@ -109,6 +119,7 @@ describe('Extension entry point', () => {
 			sendRequest,
 			start,
 			stop,
+			dispose,
 		} as unknown as LanguageClient;
 
 		// eslint-disable-next-line prefer-arrow-callback -- Must be constructable via `new`
@@ -119,13 +130,6 @@ describe('Extension entry point', () => {
 		) {
 			return languageClientInstance;
 		});
-		// eslint-disable-next-line prefer-arrow-callback -- Must be constructable via `new`
-		mockSettingMonitor = vi.fn(function MockSettingMonitor() {
-			return {
-				start: settingMonitorStart,
-			} as unknown as SettingMonitor;
-		});
-
 		const overrides: ExtensionOverrideEntry[] = [
 			[extensionTokens.workspace, mockWorkspace],
 			[extensionTokens.commands, mockCommands],
@@ -134,7 +138,6 @@ describe('Extension entry point', () => {
 				extensionTokens.languageClientModule,
 				{
 					LanguageClient: mockLanguageClient as unknown as LanguageClientModule['LanguageClient'],
-					SettingMonitor: mockSettingMonitor as unknown as LanguageClientModule['SettingMonitor'],
 				} as LanguageClientModule,
 			],
 		];
@@ -264,26 +267,23 @@ describe('Extension entry point', () => {
 
 		await registerCommandMock.mock.calls[1][1]();
 
-		expect(stop).toHaveBeenCalled();
+		expect(dispose).toHaveBeenCalled();
 		expect(start).toHaveBeenCalled();
 	});
 
-	it('should monitor settings', async () => {
-		const disposable = { dispose: () => undefined };
-
-		settingMonitorStart.mockReturnValueOnce(disposable);
-
+	it('should monitor stylelint.enable setting', async () => {
 		await activate(mockExtensionContext, moduleOverrides);
 
 		const { subscriptions } = mockExtensionContext;
+		const onDidChangeCfg = mockWorkspace.onDidChangeConfiguration as ReturnType<typeof vi.fn>;
 
-		const mockLanguageClientInstance = mockLanguageClient.mock.results[0].value;
+		// Called twice, once for restart settings handler, once for enable handler.
+		expect(onDidChangeCfg).toHaveBeenCalledTimes(2);
 
-		expect(mockSettingMonitor).toHaveBeenCalled();
-		expect(mockSettingMonitor.mock.calls[0][0]).toBe(mockLanguageClientInstance);
-		expect(mockSettingMonitor.mock.calls[0][1]).toBe('stylelint.enable');
-		expect(settingMonitorStart).toHaveBeenCalled();
-		expect(subscriptions).toContain(disposable);
+		// The enable handler's disposable should be in subscriptions.
+		const enableHandlerDisposable = onDidChangeCfg.mock.results[1].value;
+
+		expect(subscriptions).toContain(enableHandlerDisposable);
 	});
 
 	it('should listen for the DidRegisterCodeActionRequestHandler notification', async () => {
@@ -411,15 +411,15 @@ describe('Extension entry point', () => {
 		expect(showErrorMessageMock.mock.calls[1]).toEqual(['Stylelint: String problem!']);
 	});
 
-	it('should stop language client on deactivate', async () => {
+	it('should dispose language client on deactivate', async () => {
 		await activate(mockExtensionContext, moduleOverrides);
 		await deactivate();
 
-		expect(stop).toHaveBeenCalledTimes(1);
+		expect(dispose).toHaveBeenCalledTimes(1);
 	});
 
-	it('should show error message when deactivate fails to stop the client', async () => {
-		stop.mockImplementation(() => {
+	it('should show error message when deactivate fails to dispose the client', async () => {
+		dispose.mockImplementation(() => {
 			throw new Error('foo');
 		});
 
@@ -437,8 +437,8 @@ describe('Extension entry point', () => {
 		);
 	});
 
-	it('should show unknown error message when deactivate fails to stop the client', async () => {
-		stop.mockImplementation(() => {
+	it('should show unknown error message when deactivate fails to dispose the client', async () => {
+		dispose.mockImplementation(() => {
 			throw undefined; // eslint-disable-line @typescript-eslint/only-throw-error
 		});
 

--- a/src/extension/di-tokens.ts
+++ b/src/extension/di-tokens.ts
@@ -2,12 +2,7 @@
 
 import type * as vscode from 'vscode';
 import type { ExtensionContext } from 'vscode';
-import type {
-	LanguageClient,
-	LanguageClientOptions,
-	ServerOptions,
-	SettingMonitor,
-} from 'vscode-languageclient/node';
+import type { LanguageClientOptions } from 'vscode-languageclient/node';
 type LanguageClientModule = typeof import('vscode-languageclient/node');
 
 import { createToken } from '../di/index.js';
@@ -16,15 +11,10 @@ import type { PublicApi } from './types.js';
 export const extensionTokens = {
 	context: createToken<ExtensionContext>('extension-context'),
 	serverModulePath: createToken<string>('extension-server-module-path'),
-	serverOptions: createToken<ServerOptions>('extension-server-options'),
 	clientOptions: createToken<LanguageClientOptions>('extension-client-options'),
 	workspace: createToken<typeof vscode.workspace>('extension-workspace'),
 	commands: createToken<typeof vscode.commands>('extension-commands'),
 	window: createToken<typeof vscode.window>('extension-window'),
 	languageClientModule: createToken<LanguageClientModule>('extension-language-client-module'),
-	settingMonitorFactory: createToken<(client: LanguageClient) => SettingMonitor>(
-		'extension-setting-monitor-factory',
-	),
-	languageClient: createToken<LanguageClient>('extension-language-client'),
 	publicApi: createToken<PublicApi>('extension-public-api'),
 } as const;

--- a/src/extension/extension-runtime.service.ts
+++ b/src/extension/extension-runtime.service.ts
@@ -12,7 +12,7 @@ import {
 } from '../server/index.js';
 import { extensionTokens } from './di-tokens.js';
 import type { VSCodeCommands, VSCodeWindow, VSCodeWorkspace } from './services/environment.js';
-import type { SettingMonitorFactory } from './services/language-client.js';
+import { LanguageClientService } from './services/language-client.service.js';
 import { ApiEvent, type PublicApi } from './types.js';
 
 const workspaceNotificationError =
@@ -21,64 +21,67 @@ const workspaceNotificationError =
 @runtimeService()
 @inject({
 	inject: [
-		extensionTokens.languageClient,
+		LanguageClientService,
 		extensionTokens.window,
 		extensionTokens.commands,
 		extensionTokens.workspace,
 		extensionTokens.context,
-		extensionTokens.settingMonitorFactory,
 		extensionTokens.publicApi,
 	],
 })
 export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
-	readonly #client: LanguageClient;
+	readonly #languageClientService: LanguageClientService;
 	readonly #window: VSCodeWindow;
 	readonly #commands: VSCodeCommands;
 	readonly #workspace: VSCodeWorkspace;
 	readonly #context: ExtensionContext;
-	readonly #createSettingMonitor: SettingMonitorFactory;
 	readonly #api: PublicApi;
 	readonly #notificationDisposables: Disposable[] = [];
 	readonly #commandDisposables: Disposable[] = [];
+	#client: LanguageClient;
 	#settingMonitorDisposable?: Disposable;
 	#configChangeDisposable?: Disposable;
-	#initialLogLevel: string | undefined;
+	#settingSnapshots = new Map<string, string>();
+	#needsRecreate = false;
 
 	constructor(
-		languageClient: LanguageClient,
+		languageClientService: LanguageClientService,
 		window: VSCodeWindow,
 		commands: VSCodeCommands,
 		workspace: VSCodeWorkspace,
 		context: ExtensionContext,
-		settingMonitorFactory: SettingMonitorFactory,
 		api: PublicApi,
 	) {
-		this.#client = languageClient;
+		this.#languageClientService = languageClientService;
 		this.#window = window;
 		this.#commands = commands;
 		this.#workspace = workspace;
 		this.#context = context;
-		this.#createSettingMonitor = settingMonitorFactory;
 		this.#api = api;
+		this.#client = this.#languageClientService.createClient();
 	}
 
 	async onStart(): Promise<void> {
-		try {
-			await this.#startClient();
-		} catch (error) {
-			await this.#showError(error);
-		}
-
-		await this.#resetWorkspaceState();
 		this.#registerCommands();
 		this.#registerConfigurationChangeHandler();
 
-		this.#settingMonitorDisposable = this.#createSettingMonitor(this.#client).start();
+		this.#settingMonitorDisposable = this.#createEnableSettingHandler();
 		this.#context.subscriptions.push(this.#settingMonitorDisposable);
+
+		try {
+			await this.#startClient();
+		} catch (error) {
+			this.#needsRecreate = true;
+			await this.#showError(error);
+
+			return;
+		}
+
+		await this.#resetWorkspaceState();
 	}
 
 	async onShutdown(): Promise<void> {
-		await this.#stopClient();
+		await this.#disposeClient();
 		this.#disposeNotifications();
 		this.#disposeCommands();
 
@@ -108,11 +111,48 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 		this.#registerNotificationHandlers();
 	}
 
-	async #stopClient(): Promise<void> {
+	/**
+	 * Watches stylelint.enable and starts/stops the current client accordingly.
+	 * Returns a disposable that removes the listener.
+	 */
+	#createEnableSettingHandler(): Disposable {
+		return this.#workspace.onDidChangeConfiguration(async (event) => {
+			if (!event.affectsConfiguration('stylelint.enable')) {
+				return;
+			}
+
+			const enabled = this.#workspace.getConfiguration('stylelint').get<boolean>('enable', true);
+
+			if (enabled && (this.#needsRecreate || this.#client.needsStart())) {
+				try {
+					if (this.#needsRecreate) {
+						this.#needsRecreate = false;
+						await this.#disposeClient();
+						this.#client = this.#languageClientService.createClient();
+					}
+
+					await this.#startClient();
+				} catch (error) {
+					this.#needsRecreate = true;
+					await this.#showError(error);
+				}
+			} else if (!enabled && this.#client.needsStop()) {
+				try {
+					await this.#client.stop();
+				} catch (error) {
+					if (!this.#isClientInactiveError(error)) {
+						await this.#showError(error);
+					}
+				}
+			}
+		});
+	}
+
+	async #disposeClient(): Promise<void> {
 		try {
-			await this.#client.stop();
+			await this.#client.dispose();
 		} catch (error) {
-			if (this.#isConnectionDisposedError(error)) {
+			if (this.#isClientInactiveError(error)) {
 				return;
 			}
 
@@ -123,17 +163,19 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 	#registerNotificationHandlers(): void {
 		this.#disposeNotifications();
 
+		const client = this.#client;
+
 		this.#notificationDisposables.push(
-			this.#client.onNotification(Notification.DidRegisterCodeActionRequestHandler, () => {
+			client.onNotification(Notification.DidRegisterCodeActionRequestHandler, () => {
 				this.#api.codeActionReady = true;
 			}),
-			this.#client.onNotification(
+			client.onNotification(
 				Notification.DidRegisterDocumentFormattingEditProvider,
 				(params: DidRegisterDocumentFormattingEditProviderNotificationParams) => {
 					this.#api.emit(ApiEvent.DidRegisterDocumentFormattingEditProvider, params);
 				},
 			),
-			this.#client.onNotification(Notification.DidResetConfiguration, () => {
+			client.onNotification(Notification.DidResetConfiguration, () => {
 				this.#api.emit(ApiEvent.DidResetConfiguration);
 			}),
 		);
@@ -167,24 +209,35 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 		);
 
 		const restartDisposable = this.#commands.registerCommand('stylelint.restart', async () => {
-			await this.#resetWorkspaceState();
+			this.#settingMonitorDisposable?.dispose();
+			this.#settingMonitorDisposable = undefined;
+			this.#disposeNotifications();
 
 			try {
-				await this.#client.stop();
+				await this.#disposeClient();
 			} catch (error) {
-				if (!this.#isConnectionDisposedError(error)) {
+				if (!this.#isClientInactiveError(error)) {
 					await this.#showError(error);
 
 					return;
 				}
 			}
 
-			try {
-				await this.#startClient();
-				await this.#resetWorkspaceState();
-			} catch (error) {
-				await this.#showError(error);
+			this.#client = this.#languageClientService.createClient();
+			this.#needsRecreate = false;
+
+			const enabled = this.#workspace.getConfiguration('stylelint').get<boolean>('enable', true);
+
+			if (enabled) {
+				try {
+					await this.#startClient();
+					await this.#resetWorkspaceState();
+				} catch (error) {
+					await this.#showError(error);
+				}
 			}
+
+			this.#settingMonitorDisposable = this.#createEnableSettingHandler();
 		});
 
 		this.#registerDisposable(executeAutofixDisposable);
@@ -192,29 +245,100 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 	}
 
 	#registerConfigurationChangeHandler(): void {
-		this.#initialLogLevel = this.#workspace.getConfiguration('stylelint').get<string>('logLevel');
+		/**
+		 * Settings that require a restart when changed. Each entry maps a
+		 * setting key under "stylelint." to the restart strategy. "server"
+		 * means just the language server needs a restart, "extension-host"
+		 * means the entire extension host needs a restart for the setting to
+		 * take effect.
+		 */
+		const restartSettings: Record<string, 'extension-host' | 'server'> = {
+			logLevel: 'extension-host',
+			runtime: 'server',
+			execArgv: 'server',
+		};
+
+		const settingKeys = Object.keys(restartSettings);
+
+		// Snapshot current values.
+		const config = this.#workspace.getConfiguration('stylelint');
+
+		for (const key of settingKeys) {
+			this.#settingSnapshots.set(key, JSON.stringify(config.get(key)));
+		}
 
 		this.#configChangeDisposable = this.#workspace.onDidChangeConfiguration(async (event) => {
-			if (!event.affectsConfiguration('stylelint.logLevel')) {
+			const qualifiedKeys = settingKeys.map((key) => `stylelint.${key}`);
+
+			if (!qualifiedKeys.some((qk) => event.affectsConfiguration(qk))) {
 				return;
 			}
 
-			const newLogLevel = this.#workspace.getConfiguration('stylelint').get<string>('logLevel');
+			const currentConfig = this.#workspace.getConfiguration('stylelint');
 
-			if (newLogLevel === this.#initialLogLevel) {
+			let needsExtensionHostRestart = false;
+			const changedSettings = new Set<string>();
+
+			for (const key of settingKeys) {
+				const newValue = JSON.stringify(currentConfig.get(key));
+
+				if (newValue !== this.#settingSnapshots.get(key)) {
+					this.#settingSnapshots.set(key, newValue);
+					changedSettings.add(key);
+
+					if (restartSettings[key] === 'extension-host') {
+						needsExtensionHostRestart = true;
+					}
+				}
+			}
+
+			// When an extension host restart is needed, only mention those
+			// settings in the message, since only those settings actually
+			// require the full restart.
+			const relevantKeys = needsExtensionHostRestart
+				? [...changedSettings].filter((k) => restartSettings[k] === 'extension-host')
+				: [...changedSettings];
+
+			if (relevantKeys.length === 0) {
 				return;
 			}
 
-			this.#initialLogLevel = newLogLevel;
+			this.#needsRecreate = true;
 
-			const restartAction = 'Restart Extension Host';
+			const enabled = currentConfig.get<boolean>('enable', true);
+
+			// When the extension is disabled, only extension host changes still
+			// need a prompt. The enable handler will recreate the client when
+			// the user re-enables.
+			//
+			// Likewise, if enable just flipped to true in the same edit, the
+			// the enable handler will pick up #needsRecreate and handle the
+			// server restart, so skip the redundant prompt.
+			if (
+				!needsExtensionHostRestart &&
+				(!enabled || event.affectsConfiguration('stylelint.enable'))
+			) {
+				return;
+			}
+
+			const subject =
+				relevantKeys.length === 1
+					? `The stylelint.${relevantKeys[0]} setting has`
+					: 'Stylelint server settings have';
+
+			const { label, command } = needsExtensionHostRestart
+				? { label: 'Restart Extension Host', command: 'workbench.action.restartExtensionHost' }
+				: { label: 'Restart Stylelint Server', command: 'stylelint.restart' };
+
+			const target = needsExtensionHostRestart ? 'extension host' : 'Stylelint server';
+
 			const result = await this.#window.showInformationMessage(
-				'The log level setting has changed. Restart the extension host for the change to take effect.',
-				restartAction,
+				`${subject} changed. Restart the ${target} for the change to take effect.`,
+				label,
 			);
 
-			if (result === restartAction) {
-				await this.#commands.executeCommand('workbench.action.restartExtensionHost');
+			if (result === label) {
+				await this.#commands.executeCommand(command);
 			}
 		});
 
@@ -268,7 +392,14 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 		);
 	}
 
-	#isConnectionDisposedError(error: unknown): boolean {
-		return error instanceof Error && error.message.includes('connection got disposed');
+	#isClientInactiveError(error: unknown): boolean {
+		if (!(error instanceof Error)) {
+			return false;
+		}
+
+		return (
+			error.message.includes('connection got disposed') ||
+			error.message.includes("can't be stopped")
+		);
 	}
 }

--- a/src/extension/extension.module.ts
+++ b/src/extension/extension.module.ts
@@ -5,37 +5,19 @@ import { extensionTokens } from './di-tokens.js';
 import { ExtensionRuntimeService } from './extension-runtime.service.js';
 import {
 	createClientOptions,
-	createLanguageClient,
 	createPublicApi,
-	createServerOptions,
-	createSettingMonitorFactory,
+	LanguageClientService,
+	ServerOptionsService,
 } from './services/index.js';
 
 export const extensionModule = module({
 	register: [
-		{
-			token: extensionTokens.serverOptions,
-			inject: [extensionTokens.serverModulePath, extensionTokens.workspace],
-			useFactory: createServerOptions,
-		},
+		ServerOptionsService,
+		LanguageClientService,
 		{
 			token: extensionTokens.clientOptions,
-			inject: [extensionTokens.workspace],
+			inject: [extensionTokens.workspace, extensionTokens.window],
 			useFactory: createClientOptions,
-		},
-		{
-			token: extensionTokens.settingMonitorFactory,
-			inject: [extensionTokens.languageClientModule],
-			useFactory: createSettingMonitorFactory,
-		},
-		{
-			token: extensionTokens.languageClient,
-			inject: [
-				extensionTokens.languageClientModule,
-				extensionTokens.serverOptions,
-				extensionTokens.clientOptions,
-			],
-			useFactory: createLanguageClient,
 		},
 		provideValue(extensionTokens.publicApi, createPublicApi),
 		ExtensionRuntimeService,

--- a/src/extension/services/__tests__/language-client.service.test.ts
+++ b/src/extension/services/__tests__/language-client.service.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
+
+import { createContainer, module, provideTestValue } from '../../../di/index.js';
+import { extensionTokens } from '../../di-tokens.js';
+import type { LanguageClientModule } from '../environment.js';
+import { LanguageClientService } from '../language-client.service.js';
+import { ServerOptionsService } from '../server-options.service.js';
+
+describe('LanguageClientService', () => {
+	const mockServerOptions = { run: { module: '/mock/server.js' } } as ServerOptions;
+	const mockClientOptions = { documentSelector: [] } as LanguageClientOptions;
+	let createdClients: object[];
+	let mockLanguageClientModule: LanguageClientModule;
+	let mockServerOptionsService: ServerOptionsService;
+	let service: LanguageClientService;
+
+	beforeEach(() => {
+		createdClients = [];
+
+		// eslint-disable-next-line prefer-arrow-callback -- Must be constructable via new
+		const FakeClient = vi.fn(function FakeLanguageClient() {
+			const instance = {};
+
+			createdClients.push(instance);
+
+			return instance;
+		});
+
+		mockLanguageClientModule = {
+			LanguageClient: FakeClient as unknown as LanguageClientModule['LanguageClient'],
+			SettingMonitor: class {} as never,
+		} as unknown as LanguageClientModule;
+
+		mockServerOptionsService = {
+			getServerOptions: vi.fn(() => mockServerOptions),
+		} as unknown as ServerOptionsService;
+
+		const container = createContainer(
+			module({
+				register: [
+					provideTestValue(extensionTokens.languageClientModule, () => mockLanguageClientModule),
+					provideTestValue(extensionTokens.clientOptions, () => mockClientOptions),
+					{
+						token: ServerOptionsService,
+						useFactory: () => mockServerOptionsService,
+					},
+					LanguageClientService,
+				],
+			}),
+		);
+
+		service = container.resolve(LanguageClientService);
+	});
+
+	it('should create a language client with correct arguments', () => {
+		const client = service.createClient();
+		const ctor = mockLanguageClientModule.LanguageClient as unknown as ReturnType<typeof vi.fn>;
+
+		expect(client).toBe(createdClients[0]);
+		expect(ctor).toHaveBeenCalledWith('Stylelint', mockServerOptions, mockClientOptions);
+	});
+
+	it('should create a new client each time', () => {
+		const first = service.createClient();
+		const second = service.createClient();
+
+		expect(first).not.toBe(second);
+		expect(createdClients).toHaveLength(2);
+	});
+
+	it('should get fresh server options for each client', () => {
+		const freshOptions = { run: { module: '/new/server.js' } } as ServerOptions;
+
+		service.createClient();
+
+		(mockServerOptionsService.getServerOptions as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+			freshOptions,
+		);
+
+		service.createClient();
+
+		const ctor = mockLanguageClientModule.LanguageClient as unknown as ReturnType<typeof vi.fn>;
+
+		expect(ctor).toHaveBeenLastCalledWith('Stylelint', freshOptions, mockClientOptions);
+	});
+});

--- a/src/extension/services/__tests__/language-client.test.ts
+++ b/src/extension/services/__tests__/language-client.test.ts
@@ -1,17 +1,7 @@
 import { describe, expect, test } from 'vitest';
-import type {
-	LanguageClient,
-	LanguageClientOptions,
-	ServerOptions,
-} from 'vscode-languageclient/node';
 
-import {
-	createClientOptions,
-	createLanguageClient,
-	createServerOptions,
-	createSettingMonitorFactory,
-} from '../language-client.js';
-import type { LanguageClientModule, VSCodeWorkspace } from '../environment.js';
+import { createClientOptions } from '../language-client.js';
+import type { VSCodeWindow, VSCodeWorkspace } from '../environment.js';
 
 describe('language client services', () => {
 	test('createClientOptions configures selectors and file watchers', () => {
@@ -24,10 +14,16 @@ describe('language client services', () => {
 			},
 		} as unknown as VSCodeWorkspace;
 
-		const options = createClientOptions(workspace);
+		const mockOutputChannel = { name: 'Stylelint' };
+		const window = {
+			createOutputChannel: () => mockOutputChannel,
+		} as unknown as VSCodeWindow;
+
+		const options = createClientOptions(workspace, window);
 
 		expect(options.documentSelector).toEqual([{ scheme: 'file' }, { scheme: 'untitled' }]);
 		expect(options.diagnosticCollectionName).toBe('Stylelint');
+		expect(options.outputChannel).toBe(mockOutputChannel);
 		expect(watchedPatterns).toEqual([
 			'**/.stylelintrc{,.js,.cjs,.mjs,.json,.yaml,.yml}',
 			'**/stylelint.config.{js,cjs,mjs}',
@@ -36,76 +32,5 @@ describe('language client services', () => {
 			'**/.pnp.{cjs,js}',
 			'**/.pnp.loader.mjs',
 		]);
-	});
-
-	test('createServerOptions provides run and debug entries', () => {
-		const workspace = {
-			getConfiguration: () => ({
-				get: (key: string) => (key === 'logLevel' ? 'debug' : undefined),
-			}),
-		} as unknown as VSCodeWorkspace;
-		const options = createServerOptions('/tmp/server.js', workspace);
-		const serverOptions = options as {
-			run: { module: string; options?: { env?: Record<string, string> } };
-			debug: { module: string; options?: { env?: Record<string, string>; execArgv?: string[] } };
-		};
-
-		expect(serverOptions.run.module).toBe('/tmp/server.js');
-		expect(serverOptions.debug.module).toBe('/tmp/server.js');
-		expect(serverOptions.debug.options?.execArgv).toEqual(['--nolazy', '--inspect=6004']);
-		expect(serverOptions.run.options?.env?.STYLELINT_LOG_LEVEL).toBe('debug');
-		expect(serverOptions.debug.options?.env?.STYLELINT_LOG_LEVEL).toBe('debug');
-	});
-
-	test('createSettingMonitorFactory wires monitor to client', () => {
-		class FakeSettingMonitor {
-			constructor(
-				public client: LanguageClient,
-				public section: string,
-			) {}
-		}
-
-		const module = {
-			LanguageClient: class {} as never,
-			SettingMonitor: FakeSettingMonitor,
-		} as unknown as LanguageClientModule;
-
-		const factory = createSettingMonitorFactory(module);
-		const client = {} as LanguageClient;
-		const monitor = factory(client) as unknown as FakeSettingMonitor;
-
-		expect(monitor).toBeInstanceOf(FakeSettingMonitor);
-		expect(monitor.client).toBe(client);
-		expect(monitor.section).toBe('stylelint.enable');
-	});
-
-	test('createLanguageClient instantiates the module LanguageClient', () => {
-		class FakeLanguageClient {
-			static lastArgs: [string, ServerOptions, LanguageClientOptions] | undefined;
-			constructor(
-				public name: string,
-				public serverOptions: ServerOptions,
-				public clientOptions: LanguageClientOptions,
-			) {
-				FakeLanguageClient.lastArgs = [name, serverOptions, clientOptions];
-			}
-		}
-
-		const module = {
-			SettingMonitor: class {} as never,
-			LanguageClient: FakeLanguageClient,
-		} as unknown as LanguageClientModule;
-
-		const serverOptions = { run: { module: 'run' }, debug: { module: 'debug' } } as ServerOptions;
-		const clientOptions = { documentSelector: [] } as LanguageClientOptions;
-
-		const client = createLanguageClient(
-			module,
-			serverOptions,
-			clientOptions,
-		) as unknown as FakeLanguageClient;
-
-		expect(client).toBeInstanceOf(FakeLanguageClient);
-		expect(FakeLanguageClient.lastArgs).toEqual(['Stylelint', serverOptions, clientOptions]);
 	});
 });

--- a/src/extension/services/__tests__/server-options.service.test.ts
+++ b/src/extension/services/__tests__/server-options.service.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { NodeModule } from 'vscode-languageclient/node';
+
+import { createContainer, module, provideTestValue } from '../../../di/index.js';
+import { extensionTokens } from '../../di-tokens.js';
+import type { VSCodeWorkspace } from '../environment.js';
+import { ServerOptionsService } from '../server-options.service.js';
+
+type ModuleServerOptions = { run: NodeModule; debug: NodeModule };
+
+function createWorkspace(settings: Record<string, unknown> = {}): VSCodeWorkspace {
+	return {
+		getConfiguration: () => ({
+			get: (key: string, defaultValue?: unknown) => settings[key] ?? defaultValue ?? undefined,
+		}),
+	} as unknown as VSCodeWorkspace;
+}
+
+describe('ServerOptionsService', () => {
+	let service: ServerOptionsService;
+	let workspace: VSCodeWorkspace;
+
+	beforeEach(() => {
+		workspace = createWorkspace();
+
+		const container = createContainer(
+			module({
+				register: [
+					provideTestValue(extensionTokens.serverModulePath, () => '/mock/server.js'),
+					provideTestValue(extensionTokens.workspace, () => workspace),
+					ServerOptionsService,
+				],
+			}),
+		);
+
+		service = container.resolve(ServerOptionsService);
+	});
+
+	it('should return server options with module path', () => {
+		const options = service.getServerOptions() as ModuleServerOptions;
+
+		expect(options.run.module).toBe('/mock/server.js');
+		expect(options.debug.module).toBe('/mock/server.js');
+	});
+
+	it('should include debug exec args in debug options', () => {
+		const options = service.getServerOptions() as ModuleServerOptions;
+
+		expect(options.debug.options?.execArgv).toEqual(['--nolazy', '--inspect=6004']);
+	});
+
+	it('should set log level in environment', () => {
+		workspace = createWorkspace({ logLevel: 'debug' });
+
+		const container = createContainer(
+			module({
+				register: [
+					provideTestValue(extensionTokens.serverModulePath, () => '/mock/server.js'),
+					provideTestValue(extensionTokens.workspace, () => workspace),
+					ServerOptionsService,
+				],
+			}),
+		);
+
+		service = container.resolve(ServerOptionsService);
+		const options = service.getServerOptions() as ModuleServerOptions;
+
+		expect(options.run.options?.env?.STYLELINT_LOG_LEVEL).toBe('debug');
+		expect(options.debug.options?.env?.STYLELINT_LOG_LEVEL).toBe('debug');
+	});
+
+	it('should include runtime when configured', () => {
+		workspace = createWorkspace({ runtime: '/usr/local/bin/node' });
+
+		const container = createContainer(
+			module({
+				register: [
+					provideTestValue(extensionTokens.serverModulePath, () => '/mock/server.js'),
+					provideTestValue(extensionTokens.workspace, () => workspace),
+					ServerOptionsService,
+				],
+			}),
+		);
+
+		service = container.resolve(ServerOptionsService);
+		const options = service.getServerOptions() as ModuleServerOptions;
+
+		expect(options.run.runtime).toBe('/usr/local/bin/node');
+		expect(options.debug.runtime).toBe('/usr/local/bin/node');
+	});
+
+	it('should not include runtime when not configured', () => {
+		const options = service.getServerOptions() as ModuleServerOptions;
+
+		expect(options.run).not.toHaveProperty('runtime');
+		expect(options.debug).not.toHaveProperty('runtime');
+	});
+
+	it('should include execArgv when configured', () => {
+		workspace = createWorkspace({ execArgv: ['--max-old-space-size=4096'] });
+
+		const container = createContainer(
+			module({
+				register: [
+					provideTestValue(extensionTokens.serverModulePath, () => '/mock/server.js'),
+					provideTestValue(extensionTokens.workspace, () => workspace),
+					ServerOptionsService,
+				],
+			}),
+		);
+
+		service = container.resolve(ServerOptionsService);
+		const options = service.getServerOptions() as ModuleServerOptions;
+
+		expect(options.run.options?.execArgv).toEqual(['--max-old-space-size=4096']);
+		expect(options.debug.options?.execArgv).toEqual([
+			'--max-old-space-size=4096',
+			'--nolazy',
+			'--inspect=6004',
+		]);
+	});
+});

--- a/src/extension/services/index.ts
+++ b/src/extension/services/index.ts
@@ -1,3 +1,5 @@
 export * from './environment.js';
 export * from './language-client.js';
+export * from './language-client.service.js';
 export * from './public-api.js';
+export * from './server-options.service.js';

--- a/src/extension/services/language-client.service.ts
+++ b/src/extension/services/language-client.service.ts
@@ -1,0 +1,37 @@
+import type { LanguageClient, LanguageClientOptions } from 'vscode-languageclient/node';
+
+import { inject } from '../../di/index.js';
+import { extensionTokens } from '../di-tokens.js';
+import type { LanguageClientModule } from './environment.js';
+import { ServerOptionsService } from './server-options.service.js';
+
+@inject({
+	inject: [
+		extensionTokens.languageClientModule,
+		ServerOptionsService,
+		extensionTokens.clientOptions,
+	],
+})
+export class LanguageClientService {
+	readonly #languageClientModule: LanguageClientModule;
+	readonly #serverOptionsService: ServerOptionsService;
+	readonly #clientOptions: LanguageClientOptions;
+
+	constructor(
+		languageClientModule: LanguageClientModule,
+		serverOptionsService: ServerOptionsService,
+		clientOptions: LanguageClientOptions,
+	) {
+		this.#languageClientModule = languageClientModule;
+		this.#serverOptionsService = serverOptionsService;
+		this.#clientOptions = clientOptions;
+	}
+
+	createClient(): LanguageClient {
+		return new this.#languageClientModule.LanguageClient(
+			'Stylelint',
+			this.#serverOptionsService.getServerOptions(),
+			this.#clientOptions,
+		);
+	}
+}

--- a/src/extension/services/language-client.ts
+++ b/src/extension/services/language-client.ts
@@ -1,20 +1,14 @@
-import process from 'node:process';
-import type {
-	LanguageClient,
-	LanguageClientOptions,
-	ServerOptions,
-	SettingMonitor,
-} from 'vscode-languageclient/node';
+import type { LanguageClientOptions } from 'vscode-languageclient/node';
 
-import type { LanguageClientModule, VSCodeWorkspace } from './environment.js';
-import { parseLogLevel } from '../../shared/log-level.js';
-
-export type SettingMonitorFactory = (client: LanguageClient) => SettingMonitor;
+import type { VSCodeWindow, VSCodeWorkspace } from './environment.js';
 
 /**
  * Builds the language client options for Stylelint.
  */
-export function createClientOptions(workspace: VSCodeWorkspace): LanguageClientOptions {
+export function createClientOptions(
+	workspace: VSCodeWorkspace,
+	window: VSCodeWindow,
+): LanguageClientOptions {
 	const watchedFiles = [
 		'**/.stylelintrc{,.js,.cjs,.mjs,.json,.yaml,.yml}',
 		'**/stylelint.config.{js,cjs,mjs}',
@@ -27,54 +21,9 @@ export function createClientOptions(workspace: VSCodeWorkspace): LanguageClientO
 	return {
 		documentSelector: [{ scheme: 'file' }, { scheme: 'untitled' }],
 		diagnosticCollectionName: 'Stylelint',
+		outputChannel: window.createOutputChannel('Stylelint'),
 		synchronize: {
 			fileEvents: watchedFiles.map((pattern) => workspace.createFileSystemWatcher(pattern)),
 		},
 	};
-}
-
-/**
- * Creates the run/debug configuration for the language server process.
- */
-export function createServerOptions(modulePath: string, workspace: VSCodeWorkspace): ServerOptions {
-	const configuredLogLevel = workspace.getConfiguration('stylelint').get<string>('logLevel');
-	const logLevel = parseLogLevel(configuredLogLevel) ?? 'info';
-	const env = { ...process.env, STYLELINT_LOG_LEVEL: logLevel };
-
-	return {
-		run: {
-			module: modulePath,
-			options: {
-				env,
-			},
-		},
-		debug: {
-			module: modulePath,
-			options: {
-				execArgv: ['--nolazy', '--inspect=6004'],
-				env,
-			},
-		},
-	};
-}
-
-/**
- * Creates a factory that wires the VS Code SettingMonitor to the client instance.
- */
-export function createSettingMonitorFactory(
-	languageClientModule: LanguageClientModule,
-): SettingMonitorFactory {
-	return (client: LanguageClient) =>
-		new languageClientModule.SettingMonitor(client, 'stylelint.enable');
-}
-
-/**
- * Instantiates the Stylelint language client with the resolved dependencies.
- */
-export function createLanguageClient(
-	languageClientModule: LanguageClientModule,
-	serverOptions: ServerOptions,
-	clientOptions: LanguageClientOptions,
-): LanguageClient {
-	return new languageClientModule.LanguageClient('Stylelint', serverOptions, clientOptions);
 }

--- a/src/extension/services/server-options.service.ts
+++ b/src/extension/services/server-options.service.ts
@@ -1,0 +1,51 @@
+import process from 'node:process';
+import type { ServerOptions } from 'vscode-languageclient/node';
+
+import { inject } from '../../di/index.js';
+import { parseLogLevel } from '../../shared/log-level.js';
+import { extensionTokens } from '../di-tokens.js';
+import type { VSCodeWorkspace } from './environment.js';
+
+@inject({
+	inject: [extensionTokens.serverModulePath, extensionTokens.workspace],
+})
+export class ServerOptionsService {
+	readonly #modulePath: string;
+	readonly #workspace: VSCodeWorkspace;
+
+	constructor(modulePath: string, workspace: VSCodeWorkspace) {
+		this.#modulePath = modulePath;
+		this.#workspace = workspace;
+	}
+
+	getServerOptions(): ServerOptions {
+		const config = this.#workspace.getConfiguration('stylelint');
+		const configuredLogLevel = config.get<string>('logLevel');
+		const logLevel = parseLogLevel(configuredLogLevel) ?? 'info';
+		const env = { ...process.env, STYLELINT_LOG_LEVEL: logLevel };
+
+		const runtime = config.get<string | null>('runtime', null);
+		const execArgv = config.get<string[] | null>('execArgv', null);
+
+		const debugExecArgv = ['--nolazy', '--inspect=6004'];
+
+		return {
+			run: {
+				module: this.#modulePath,
+				...(runtime && { runtime }),
+				options: {
+					...(execArgv && { execArgv }),
+					env,
+				},
+			},
+			debug: {
+				module: this.#modulePath,
+				...(runtime && { runtime }),
+				options: {
+					execArgv: execArgv ? [...execArgv, ...debugExecArgv] : debugExecArgv,
+					env,
+				},
+			},
+		};
+	}
+}

--- a/src/extension/start-server.ts
+++ b/src/extension/start-server.ts
@@ -8,6 +8,10 @@ import { parseLogLevel } from '../shared/log-level.js';
 
 const connection = createConnection(ProposedFeatures.all);
 
+connection.console.info(
+	`Stylelint language server running on Node.js ${process.version} from ${process.execPath}`,
+);
+
 const isDevelopment = process.env.NODE_ENV === 'development';
 const configuredLogLevel = parseLogLevel(process.env.STYLELINT_LOG_LEVEL);
 


### PR DESCRIPTION
Resolves #439

Add stylelint.runtime and stylelint.execArgv configuration settings that allow users to customize the Node.js binary and exec arguments used by the language server.

- Create ServerOptionsService to build fresh server options from current configuration on each client creation
- Create LanguageClientService as a factory for on-demand LanguageClient instantiation
- Replace SettingMonitor with a custom enable handler that correctly manages listener lifecycle
- Generalize configuration change handler to watch logLevel, runtime, and execArgv with per-setting restart strategies
- Add #needsRecreate flag for deferred client recreation when settings change while disabled
- Share output channel across client instances
- Log Node.js version/path at server startup
