### PR TITLE
refactor: permissive return type for onInitialize

### DIFF
--- a/src/server/__tests__/decorators.test.ts
+++ b/src/server/__tests__/decorators.test.ts
@@ -31,7 +31,7 @@ describe('server decorators', () => {
 			}
 
 			@initialize()
-			onInitialize(): Partial<LSP.InitializeResult> | void {
+			onInitialize(): Partial<LSP.InitializeResult> {
 				this.value += 10;
 
 				return { capabilities: { experimental: { ready: true } } };

--- a/src/server/decorators.ts
+++ b/src/server/decorators.ts
@@ -351,7 +351,7 @@ export function command(
 /**
  * Decorator to mark a method as an initialization handler.
  */
-export function initialize(): MethodDecoratorFunction<InitializeHandler> {
+export function initialize(): CompatibleMethodDecorator<InitializeHandler> {
 	// Function type used to match decorator signature.
 
 	return (target: Function, { kind, addInitializer }: ClassMethodDecoratorContext) => {

--- a/src/server/services/lsp/auto-fix.service.ts
+++ b/src/server/services/lsp/auto-fix.service.ts
@@ -53,7 +53,7 @@ export class AutoFixService {
 	}
 
 	@initialize()
-	onInitialize(): Partial<LSP.InitializeResult> | void {
+	onInitialize(): Partial<LSP.InitializeResult> {
 		return {
 			capabilities: {
 				executeCommandProvider: {

--- a/src/server/services/lsp/code-actions/code-action.service.ts
+++ b/src/server/services/lsp/code-actions/code-action.service.ts
@@ -61,7 +61,7 @@ export class CodeActionService {
 	}
 
 	@initialize()
-	onInitialize(): Partial<LSP.InitializeResult> | void {
+	onInitialize(): Partial<LSP.InitializeResult> {
 		return {
 			capabilities: {
 				codeActionProvider: {

--- a/src/server/services/lsp/completion.service.ts
+++ b/src/server/services/lsp/completion.service.ts
@@ -40,7 +40,7 @@ export class CompletionService {
 	}
 
 	@initialize()
-	onInitialize(): Partial<LSP.InitializeResult> | void {
+	onInitialize(): Partial<LSP.InitializeResult> {
 		return {
 			capabilities: {
 				completionProvider: {},

--- a/src/server/services/lsp/formatter.service.ts
+++ b/src/server/services/lsp/formatter.service.ts
@@ -58,7 +58,7 @@ export class FormatterLspService {
 	}
 
 	@initialize()
-	onInitialize(params?: LSP.InitializeParams): Partial<LSP.InitializeResult> | void {
+	onInitialize(params?: LSP.InitializeParams): Partial<LSP.InitializeResult> {
 		this.#registerDynamically = Boolean(
 			params?.capabilities.textDocument?.formatting?.dynamicRegistration,
 		);

--- a/src/server/services/lsp/validator.service.ts
+++ b/src/server/services/lsp/validator.service.ts
@@ -65,7 +65,7 @@ export class ValidatorLspService {
 	}
 
 	@initialize()
-	onInitialize(): Partial<LSP.InitializeResult> | void {
+	onInitialize(): Partial<LSP.InitializeResult> {
 		void this.#validateAll();
 
 		return {


### PR DESCRIPTION
Avoid need to specify type union when returning `Partial<LSP.InitializeResult>` in onInitialize.