### PR TITLE
feat: problem matchers for compact/unix formatters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added: Problem matchers for `compact` and `unix` formatters ([#864](https://github.com/stylelint/vscode-stylelint/pull/864)).
 - Fixed: Files in `node_modules` not being ignored due to a bug in Stylelint 17.4.0 and below ([#861](https://github.com/stylelint/vscode-stylelint/issues/861)).
 - Added: "Fix all \<rule\> problems" quick fix action for rules with multiple auto-fixable diagnostics ([#859](https://github.com/stylelint/vscode-stylelint/pull/859)).
 - Added: commands to lint all files and clear all problems ([#857](https://github.com/stylelint/vscode-stylelint/pull/857)).

--- a/README.md
+++ b/README.md
@@ -126,6 +126,45 @@ You can also selectively enable and disable specific languages using VS Code's l
   }
 ```
 
+### Problem Matchers
+
+The extension contributes [problem matchers](https://code.visualstudio.com/docs/debugtest/tasks#_defining-a-problem-matcher) that can be used to parse Stylelint CLI output from [VS Code tasks](https://code.visualstudio.com/docs/debugtest/tasks) into the Problems panel.
+
+Two problem matchers are available, corresponding to a selection of [Stylelint's formatters](https://stylelint.io/user-guide/options/#formatter):
+
+- **`$stylelint-compact`** for the `compact` formatter
+- **`$stylelint-unix`** for the `unix` formatter
+
+For example, to lint all CSS files using a task with the compact formatter, set up a task like so:
+
+```json
+// .vscode/tasks.json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "lint:stylelint",
+      "problemMatcher": "$stylelint-compact"
+    }
+  ]
+}
+```
+
+where `lint:stylelint` is a script running Stylelint with the compact formatter:
+
+```json
+// package.json
+{
+  "scripts": {
+    "lint:stylelint": "stylelint --formatter=compact \"**/*.css\""
+  }
+}
+```
+
+> [!NOTE]
+> Stylelint's default formatter uses multiline output, which VS Code's problem matcher system [does not fully support](https://github.com/stylelint/vscode-stylelint/issues/150#issuecomment-975191285). This is why you must use either the `compact` or `unix` formatter to use the problem matchers.
+
 ### Extension Settings
 
 Though relying on a [Stylelint configuration file](https://stylelint.io/user-guide/configure) in your project is highly recommended, you can instead use the following [extension settings](https://code.visualstudio.com/docs/getstarted/settings):

--- a/package.json
+++ b/package.json
@@ -302,6 +302,52 @@
           ".stylelintignore"
         ]
       }
+    ],
+    "problemPatterns": [
+      {
+        "name": "stylelint-compact",
+        "regexp": "^(.+): line (\\d+), col (\\d+), (\\w+) - (.*?)\\s\\(([^)]+)\\)\\s*$",
+        "file": 1,
+        "line": 2,
+        "column": 3,
+        "severity": 4,
+        "message": 5,
+        "code": 6
+      },
+      {
+        "name": "stylelint-unix",
+        "regexp": "^(.+):(\\d+):(\\d+): (.*?)\\s\\(([^)]+)\\) \\[(\\w+)\\]\\s*$",
+        "file": 1,
+        "line": 2,
+        "column": 3,
+        "message": 4,
+        "code": 5,
+        "severity": 6
+      }
+    ],
+    "problemMatchers": [
+      {
+        "name": "stylelint-compact",
+        "label": "Stylelint problems (compact formatter)",
+        "owner": "Stylelint",
+        "source": "Stylelint",
+        "fileLocation": [
+          "autoDetect",
+          "${workspaceFolder}"
+        ],
+        "pattern": "$stylelint-compact"
+      },
+      {
+        "name": "stylelint-unix",
+        "label": "Stylelint problems (unix formatter)",
+        "owner": "Stylelint",
+        "source": "Stylelint",
+        "fileLocation": [
+          "autoDetect",
+          "${workspaceFolder}"
+        ],
+        "pattern": "$stylelint-unix"
+      }
     ]
   },
   "dependencies": {

--- a/test/e2e/__tests__/problem-matchers.test.ts
+++ b/test/e2e/__tests__/problem-matchers.test.ts
@@ -1,0 +1,214 @@
+import path from 'node:path';
+import { tasks, workspace, Uri } from 'vscode';
+import {
+	assertDiagnostics,
+	closeAllEditors,
+	getStylelintDiagnostics,
+	matchVersion,
+	waitFor,
+	type ExpectedDiagnostic,
+} from '../helpers.js';
+
+/**
+ * Execute a workspace task by label and resolve when it is finished.
+ */
+async function runTask(label: string): Promise<void> {
+	const allTasks = await tasks.fetchTasks();
+	const task = allTasks.find((t) => t.name === label);
+
+	if (!task) {
+		const available = allTasks.map((t) => t.name).join(', ');
+
+		throw new Error(`Task "${label}" not found. Available: ${available}`);
+	}
+
+	return new Promise((resolve, reject) => {
+		const disposable = tasks.onDidEndTaskProcess((e) => {
+			if (e.execution.task.name === label) {
+				disposable.dispose();
+				resolve();
+			}
+		});
+
+		tasks.executeTask(task).then(undefined, (err: unknown) => {
+			disposable.dispose();
+			reject(err instanceof Error ? err : new Error(String(err)));
+		});
+	});
+}
+
+const expectedDiagnostics: ExpectedDiagnostic[] = [
+	{
+		code: 'color-hex-length',
+		message: 'Expected "#fff" to be "#ffffff"',
+		range: [4, 9, 4, 9],
+		severity: 'error',
+	},
+	{
+		code: 'value-keyword-case',
+		message: 'Expected "BLOCK" to be "block"',
+		range: [9, 11, 9, 11],
+		severity: 'error',
+	},
+	{
+		code: 'color-no-invalid-hex',
+		message: 'Unexpected invalid hex color "#abcxyz"', // cspell:disable-line
+		range: [14, 9, 14, 9],
+		severity: 'error',
+	},
+	{
+		code: 'font-family-no-duplicate-names',
+		message: matchVersion({
+			'<16': 'Unexpected duplicate name serif',
+			default: 'Unexpected duplicate font-family name serif',
+		}),
+		range: [19, 22, 19, 22],
+		severity: 'error',
+	},
+	{
+		code: 'declaration-block-no-duplicate-properties',
+		message: 'Unexpected duplicate "color"',
+		range: matchVersion({
+			'<16': [25, 2, 25, 2],
+			default: [24, 2, 24, 2],
+		}),
+		severity: 'error',
+	},
+	{
+		code: 'block-no-empty',
+		message: 'Unexpected empty block',
+		range: [29, 2, 29, 2],
+		severity: 'error',
+	},
+	{
+		code: 'number-max-precision',
+		message: 'Expected "10.123" to be "10.12"',
+		range: [33, 9, 33, 9],
+		severity: 'error',
+	},
+	{
+		code: 'selector-pseudo-class-no-unknown',
+		message: 'Unexpected unknown pseudo-class selector ":hoverr"', // cspell:disable-line
+		range: [37, 1, 37, 1],
+		severity: 'error',
+	},
+	{
+		code: 'selector-pseudo-element-colon-notation',
+		message: 'Expected double colon pseudo-element notation',
+		range: [42, 1, 42, 1],
+		severity: 'error',
+	},
+	{
+		code: 'selector-type-case',
+		message: 'Expected "A" to be "a"',
+		range: [47, 0, 47, 0],
+		severity: 'error',
+	},
+	{
+		code: 'shorthand-property-no-redundant-values',
+		message: 'Expected "1px 1px 1px 1px" to be "1px"',
+		range: matchVersion({
+			'<16': [53, 2, 53, 2],
+			default: [53, 10, 53, 10],
+		}),
+		severity: 'error',
+	},
+	{
+		code: 'declaration-block-single-line-max-declarations',
+		message: 'Expected no more than 1 declaration',
+		range: [57, 2, 57, 2],
+		severity: 'error',
+	},
+	{
+		code: 'no-duplicate-selectors',
+		message: 'Unexpected duplicate selector ".dup", first used at line 61',
+		range: [61, 0, 61, 0],
+		severity: 'error',
+	},
+	{
+		code: 'comment-no-empty',
+		message: 'Unexpected empty comment',
+		range: [64, 0, 64, 0],
+		severity: 'error',
+	},
+	{
+		code: 'font-family-name-quotes',
+		message: 'Expected quotes around "Times New Roman"',
+		range: [68, 15, 68, 15],
+		severity: 'error',
+	},
+	{
+		code: 'declaration-no-important',
+		message: 'Unexpected !important',
+		range: [73, 13, 73, 13],
+		severity: 'error',
+	},
+	{
+		code: 'unit-no-unknown',
+		message: 'Unexpected unknown unit "pxx"',
+		range: [78, 12, 78, 12],
+		severity: 'error',
+	},
+	{
+		code: 'property-no-unknown',
+		message: 'Unexpected unknown property "colr"', // cspell:disable-line
+		range: [83, 2, 83, 2],
+		severity: 'error',
+	},
+	{
+		code: 'max-nesting-depth',
+		message: 'Expected nesting depth to be no more than 2',
+		range: [90, 6, 90, 6],
+		severity: 'error',
+	},
+	{
+		code: 'selector-max-id',
+		message: 'Expected "#myid" to have no more than 0 ID selectors', // cspell:disable-line
+		range: [98, 0, 98, 0],
+		severity: 'error',
+	},
+];
+
+describe('Problem Matchers', () => {
+	const lintTaskFolder = workspace.workspaceFolders?.find(({ name }) => name === 'lint-task');
+
+	afterEach(async () => {
+		await closeAllEditors();
+	});
+
+	it('should parse compact formatter output into diagnostics', async () => {
+		if (!lintTaskFolder) {
+			throw new Error('lint-task workspace folder not found');
+		}
+
+		const testCssUri = Uri.file(path.join(lintTaskFolder.uri.fsPath, 'test.css'));
+
+		await runTask('stylelint-compact');
+
+		const diagnostics = await waitFor(
+			() => getStylelintDiagnostics(testCssUri),
+			(result) => result.length >= expectedDiagnostics.length,
+			{ timeout: 15000 },
+		);
+
+		assertDiagnostics(diagnostics, expectedDiagnostics);
+	});
+
+	it('should parse unix formatter output into diagnostics', async () => {
+		if (!lintTaskFolder) {
+			throw new Error('lint-task workspace folder not found');
+		}
+
+		const testCssUri = Uri.file(path.join(lintTaskFolder.uri.fsPath, 'test.css'));
+
+		await runTask('stylelint-unix');
+
+		const diagnostics = await waitFor(
+			() => getStylelintDiagnostics(testCssUri),
+			(result) => result.length >= expectedDiagnostics.length,
+			{ timeout: 15000 },
+		);
+
+		assertDiagnostics(diagnostics, expectedDiagnostics);
+	});
+});

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -190,7 +190,7 @@ export function waitForDiagnosticsLength(
 
 type ExpectedRange = [number, number, number, number];
 
-type ExpectedDiagnostic = {
+export type ExpectedDiagnostic = {
 	code: number | string;
 	codeDescription?: string;
 	message: string;

--- a/test/e2e/workspace/lint-task/.vscode/tasks.json
+++ b/test/e2e/workspace/lint-task/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "stylelint-compact",
+			"type": "shell",
+			"command": "../../../../node_modules/.bin/stylelint --formatter=compact test.css; echo ''",
+			"problemMatcher": "$stylelint-compact",
+			"presentation": {
+				"reveal": "silent",
+				"panel": "shared"
+			}
+		},
+		{
+			"label": "stylelint-unix",
+			"type": "shell",
+			"command": "../../../../node_modules/.bin/stylelint",
+			"args": ["--formatter=unix", "test.css"],
+			"problemMatcher": "$stylelint-unix",
+			"presentation": {
+				"reveal": "silent",
+				"panel": "shared"
+			}
+		}
+	]
+}

--- a/test/e2e/workspace/lint-task/stylelint.config.js
+++ b/test/e2e/workspace/lint-task/stylelint.config.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/** @type {import('stylelint').Config} */
+const config = {
+	rules: {
+		'color-hex-length': 'long',
+		'value-keyword-case': 'lower',
+		'color-no-invalid-hex': true,
+		'font-family-no-duplicate-names': true,
+		'declaration-block-no-duplicate-properties': true,
+		'block-no-empty': true,
+		'number-max-precision': 2,
+		'selector-pseudo-class-no-unknown': true,
+		'selector-pseudo-element-colon-notation': 'double',
+		'selector-type-case': 'lower',
+		'shorthand-property-no-redundant-values': true,
+		'declaration-block-single-line-max-declarations': 1,
+		'no-duplicate-selectors': true,
+		'comment-no-empty': true,
+		'font-family-name-quotes': 'always-where-recommended',
+		'declaration-no-important': true,
+		'unit-no-unknown': true,
+		'property-no-unknown': true,
+		'max-nesting-depth': 2,
+		'selector-max-id': 0,
+	},
+};
+
+module.exports = config;

--- a/test/e2e/workspace/lint-task/test.css
+++ b/test/e2e/workspace/lint-task/test.css
@@ -1,0 +1,101 @@
+/* prettier-ignore */ /* cspell:disable */
+
+/* color-hex-length: "long" - #fff should be #ffffff */
+a {
+  color: #fff;
+}
+
+/* value-keyword-case: "lower" - BLOCK should be block */
+b {
+  display: BLOCK;
+}
+
+/* color-no-invalid-hex - #abcxyz is not valid */
+c {
+  color: #abcxyz;
+}
+
+/* font-family-no-duplicate-names - duplicate "serif" */
+d {
+  font-family: serif, serif;
+}
+
+/* declaration-block-no-duplicate-properties - duplicate "color" */
+e {
+  color: red;
+  color: blue;
+}
+
+/* block-no-empty - empty block */
+f {}
+
+/* number-max-precision: 2 - too many decimal places */
+h {
+  width: 10.123px;
+}
+
+/* selector-pseudo-class-no-unknown - :hoverr is not real */
+i:hoverr {
+  color: red;
+}
+
+/* selector-pseudo-element-colon-notation: "double" - should be :: */
+j:before {
+  content: "";
+}
+
+/* selector-type-case: "lower" - A should be a */
+A {
+  color: red;
+}
+
+/* shorthand-property-no-redundant-values - 1px 1px 1px 1px -> 1px */
+k {
+  margin: 1px 1px 1px 1px;
+}
+
+/* declaration-block-single-line-max-declarations: 1 - too many */
+l { color: red; display: block; }
+
+/* no-duplicate-selectors - .dup appears twice */
+.dup { color: red; }
+.dup { color: blue; }
+
+/* comment-no-empty - empty comment */
+/* */
+
+/* font-family-name-quotes: "always-where-recommended" - missing quotes */
+m {
+  font-family: Times New Roman, serif;
+}
+
+/* declaration-no-important - !important is disallowed */
+o {
+  color: red !important;
+}
+
+/* unit-no-unknown - "pxx" is invalid */
+p {
+  width: 100pxx;
+}
+
+/* property-no-unknown - "colr" is not a property */
+q {
+  colr: red;
+}
+
+/* max-nesting-depth: 2 - too deeply nested */
+s {
+  & t {
+    & u {
+      & v {
+        color: red;
+      }
+    }
+  }
+}
+
+/* selector-max-id: 0 - IDs are not allowed */
+#myid {
+  color: red;
+}

--- a/test/e2e/workspace/workspace.code-workspace
+++ b/test/e2e/workspace/workspace.code-workspace
@@ -9,6 +9,7 @@
 		{ "path": "format-custom-syntax" },
 		{ "path": "ignore-disables" },
 		{ "path": "ignore-path" },
+		{ "path": "lint-task" },
 		{ "path": "no-rules-configured" },
 		{ "path": "report-disables" },
 		{ "path": "run" },


### PR DESCRIPTION
Resolves #150

Add problem matchers for the `compact` and `unix` formatters, along with tests and documentation. Support for the default formatter is not viable due to lack of multi-line matching support in VS Code.
