### PR TITLE
docs: add Problem Matchers section to readme TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The official [Visual Studio Code](https://code.visualstudio.com/) extension for 
 - [Usage](#usage)
   - [Commands](#commands)
   - [Actions](#actions)
+  - [Problem Matchers](#problem-matchers)
   - [Extension Settings](#extension-settings)
 - [Migrating](#migrating)
   - [From vscode-stylelint 1.x](#from-vscode-stylelint-1x)


### PR DESCRIPTION
Caught this little omission from #864 a little late.