### PR TITLE
chore: migrate scripts to typescript

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,7 +288,7 @@ Most test files live next to the code they exercise:
 
 - **Unit tests** live under `src/**/__tests__/` and use the naming pattern `<module>.test.ts`.
 - **Integration tests** live under `test/integration/` and cover interactions between larger pieces, such as the extension and server processes.
-- **End-to-end tests** live under `test/e2e/` and drive a real VS Code instance through `scripts/run-e2e.js`.
+- **End-to-end tests** live under `test/e2e/` and drive a real VS Code instance through `scripts/run-e2e.mts`.
 
 The `lint:unit-tests` script enforces the "one module, one unit test file" rule for everything under `src/`. When you add a new module, expect to add a matching unit test, unless you deliberately opt out with the `@no-unit-test` pragma described earlier.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,7 +26,7 @@ export default defineConfig([
 		'**/__tests__/**/*.js',
 		'**/__tests__/**/*.cjs',
 		'**/__tests__/**/*.mjs',
-		'scripts/switch-stylelint.mjs', // Contains syntax unsupported by ESLint
+		'scripts/switch-stylelint.mts', // Contains syntax unsupported by ESLint
 	]),
 
 	...stylelint,

--- a/package.json
+++ b/package.json
@@ -424,14 +424,14 @@
     "lint:types": "wireit",
     "lint:unit-tests": "wireit",
     "test": "wireit",
-    "test:e2e": "node scripts/run-e2e.js",
+    "test:e2e": "node --experimental-strip-types scripts/run-e2e.mts",
     "test:integration": "wireit",
     "test:unit": "wireit",
-    "test:node-versions": "node scripts/test-node-versions.js",
+    "test:node-versions": "node --experimental-strip-types scripts/test-node-versions.mts",
     "vscode:prepublish": "wireit",
-    "vscode:launch": "node scripts/launch-vscode.js",
+    "vscode:launch": "node --experimental-strip-types scripts/launch-vscode.mts",
     "publish": "vsce publish --no-git-tag-version --no-update-package-json",
-    "switch-stylelint": "node scripts/switch-stylelint.mjs"
+    "switch-stylelint": "node --experimental-strip-types scripts/switch-stylelint.mts"
   },
   "wireit": {
     "env": {

--- a/scripts/launch-vscode.mts
+++ b/scripts/launch-vscode.mts
@@ -1,17 +1,15 @@
-'use strict';
+import path from 'node:path';
+import { execSync, spawn } from 'node:child_process';
+import process from 'node:process';
 
-const path = require('node:path');
-const { execSync, spawn } = require('node:child_process');
-const process = require('node:process');
-
-const {
+import {
 	downloadAndUnzipVSCode,
 	resolveCliArgsFromVSCodeExecutablePath,
-} = require('@vscode/test-electron');
+} from '@vscode/test-electron';
 
-const packageJson = require('../package.json');
+import packageJson from '../package.json' with { type: 'json' };
 
-const rootDir = path.resolve(__dirname, '..');
+const rootDir = path.resolve(import.meta.dirname, '..');
 const defaultWorkspace = path.resolve(rootDir, 'test/e2e/workspace/workspace.code-workspace');
 const minimumVscodeVersion = packageJson.engines?.vscode.match(/^>=(.+)$/)?.[1];
 const allowedLogLevels = new Set(['trace', 'debug', 'info', 'warn', 'error', 'critical', 'off']);
@@ -20,12 +18,9 @@ if (!minimumVscodeVersion) {
 	throw new Error(`Unexpected VS Code engine constraint: ${packageJson.engines?.vscode}`);
 }
 
-/**
- * @param {string[]} argv
- */
-function parseLaunchArguments(argv) {
+function parseLaunchArguments(argv: string[]) {
 	let logLevel = 'debug';
-	const passthroughArgs = [];
+	const passthroughArgs: string[] = [];
 	let passthroughMode = false;
 
 	for (let index = 0; index < argv.length; index += 1) {
@@ -76,9 +71,8 @@ function parseLaunchArguments(argv) {
 
 /**
  * Builds the extension bundle and launches VS Code via @vscode/test-electron without running tests.
- * @returns {Promise<number>} The exit code of the VS Code process.
  */
-async function launchVSCode() {
+async function launchVSCode(): Promise<number> {
 	try {
 		console.log('Building bundle...');
 		execSync('node --run build-bundle', { stdio: 'inherit' });
@@ -120,8 +114,7 @@ async function launchVSCode() {
 			env,
 		});
 
-		/** @type {number} */
-		const exitCode = await new Promise((resolve) => {
+		const exitCode: number = await new Promise((resolve) => {
 			vscodeProcess.on('close', resolve);
 		});
 

--- a/scripts/run-e2e.mts
+++ b/scripts/run-e2e.mts
@@ -1,15 +1,12 @@
-'use strict';
+import { execSync, spawn } from 'node:child_process';
+import process from 'node:process';
 
-const { execSync, spawn } = require('child_process');
-const process = require('process');
-
-const packageJson = require('../package.json');
+import packageJson from '../package.json' with { type: 'json' };
 
 /**
  * Run end-to-end tests for the VS Code extension.
- * @returns {Promise<number>} The exit code to use when exiting the process.
  */
-async function runE2ETest() {
+async function runE2ETest(): Promise<number> {
 	try {
 		// Build bundle.
 		// Delete NODE_RUN_SCRIPT_NAME to work around a Windows bug where it
@@ -31,8 +28,7 @@ async function runE2ETest() {
 			stdio: 'inherit',
 		});
 
-		/** @type {number} */
-		const exitCode = await new Promise((resolve) => {
+		const exitCode: number = await new Promise((resolve) => {
 			vscodeTest.on('close', resolve);
 		});
 

--- a/scripts/switch-stylelint.mts
+++ b/scripts/switch-stylelint.mts
@@ -27,13 +27,9 @@ Examples:
 `);
 }
 
-/** @typedef { 'default' | '17' | '16' | '15' | '14' } StylelintVersion */
+type StylelintVersion = 'default' | '17' | '16' | '15' | '14';
 
-/**
- * @param {unknown} version
- * @returns {version is StylelintVersion} Whether the provided version is valid.
- */
-function isStylelintVersion(version) {
+function isStylelintVersion(version: unknown): version is StylelintVersion {
 	return (
 		version === 'default' ||
 		version === '17' ||
@@ -67,27 +63,22 @@ if (!isStylelintVersion(version)) {
 // Type wizardry to require all map entries to have the same keys, so that no
 // packages are forgotten in any version.
 
-/**
- * @template U
- * @typedef {U extends U ? keyof U : never} UnionKeys
- */
+type UnionKeys<U> = U extends U ? keyof U : never;
 
 /**
  * Helper function to help TypeScript infer the correct types for the map.
- * @template T
- * @param {T & Record<keyof T, Record<UnionKeys<T[keyof T]>, string>>} map
- * @returns {T}
  */
-function createPackageMap(map) {
+function createPackageMap<T extends Record<string, Record<string, string>>>(
+	map: T & Record<keyof T, Record<UnionKeys<T[keyof T]>, string>>,
+): T {
 	return map;
 }
 
-/**
- * @typedef {Object} InstalledPackage
- * @property {string} [version]
- * @property {string} [resolved]
- * @property {string} [from]
- */
+interface InstalledPackage {
+	version?: string;
+	resolved?: string;
+	from?: string;
+}
 
 const packageMap = createPackageMap({
 	default: {
@@ -125,11 +116,7 @@ const install = () =>
 
 const gitSpecPattern = /^(?:git\+)?(?:https?|ssh):\/\/|^(?:git|github):|\.git(?:#|$)/i;
 
-/**
- * @param {string} spec
- * @returns {{ url: string, ref: string | null }}
- */
-const parseGitSpec = (spec) => {
+const parseGitSpec = (spec: string): { url: string; ref: string | null } => {
 	const cleaned = spec.replace(/^git\+/, '');
 	const [base, ref = null] = cleaned.split('#', 2);
 
@@ -152,8 +139,7 @@ const parseGitSpec = (spec) => {
 	return { url: base.endsWith('.git') ? base : `${base}.git`, ref };
 };
 
-/** @param {string} spec */
-const normalizeGitSpec = (spec) => {
+const normalizeGitSpec = (spec: string): string => {
 	const [rawBase, ref] = spec.replace(/^git\+/, '').split('#', 2);
 	const base = rawBase
 		.replace(/^git@github\.com:/i, 'github.com/')
@@ -164,14 +150,9 @@ const normalizeGitSpec = (spec) => {
 	return `${base}${ref ? `#${ref}` : ''}`;
 };
 
-/** @param {string} spec */
-const isGitSpec = (spec) => gitSpecPattern.test(spec);
+const isGitSpec = (spec: string): boolean => gitSpecPattern.test(spec);
 
-/**
- * @param {string} pkg
- * @returns {Promise<InstalledPackage | null>}
- */
-const readInstalled = async (pkg) => {
+const readInstalled = async (pkg: string): Promise<InstalledPackage | null> => {
 	try {
 		const result = await execa('npm', ['list', pkg, '--depth=0', '--json'], {
 			stderr: 'pipe',
@@ -203,11 +184,7 @@ const readInstalled = async (pkg) => {
 	}
 };
 
-/**
- * @param {string} spec
- * @returns {Promise<string | null>}
- */
-const resolveGitSha = async (spec) => {
+const resolveGitSha = async (spec: string): Promise<string | null> => {
 	const { url, ref } = parseGitSpec(spec);
 	const targetRef = ref ?? 'HEAD';
 
@@ -224,8 +201,7 @@ const resolveGitSha = async (spec) => {
 	}
 };
 
-/** @param {string | undefined} value */
-const extractGitSha = (value) => {
+const extractGitSha = (value: string | undefined): string | null => {
 	if (!value) {
 		return null;
 	}
@@ -241,12 +217,11 @@ const extractGitSha = (value) => {
 	return sha && /^[a-f0-9]{7,40}$/i.test(sha) ? sha.toLowerCase() : null;
 };
 
-/**
- * @param {string} desiredSpec
- * @param {InstalledPackage | null} installed
- * @param {string | null} desiredGitSha
- */
-const matchesSpec = (desiredSpec, installed, desiredGitSha = null) => {
+const matchesSpec = (
+	desiredSpec: string,
+	installed: InstalledPackage | null,
+	desiredGitSha: string | null = null,
+): boolean => {
 	if (!installed) {
 		return false;
 	}
@@ -275,8 +250,7 @@ const matchesSpec = (desiredSpec, installed, desiredGitSha = null) => {
 		: false;
 };
 
-/** @param {InstalledPackage | null} installed */
-const describeInstalled = (installed) => {
+const describeInstalled = (installed: InstalledPackage | null): string => {
 	if (!installed) {
 		return 'not installed';
 	}
@@ -292,23 +266,22 @@ const describeInstalled = (installed) => {
 	return installed.version ?? 'unknown version';
 };
 
-/** @type {Array<[string, string, string | null, InstalledPackage | null]>} */
-const installedPackages = await Promise.all(
-	Object.entries(selectedPackages).map(async ([pkg, spec]) => [
-		pkg,
-		spec,
-		await resolveGitSha(spec),
-		await readInstalled(pkg),
-	]),
-);
+const installedPackages: Array<[string, string, string | null, InstalledPackage | null]> =
+	await Promise.all(
+		Object.entries(selectedPackages).map(async ([pkg, spec]) => [
+			pkg,
+			spec,
+			await resolveGitSha(spec),
+			await readInstalled(pkg),
+		]),
+	);
 
 const allMatch = installedPackages.every(([, spec, desiredGitSha, meta]) =>
 	matchesSpec(spec, meta, desiredGitSha),
 );
 
 const isDefaultVersion = Object.entries(selectedPackages).every(
-	([pkg, ver]) =>
-		/** @type {Record<string, string>} */ (packageConfig.devDependencies)[pkg] === ver,
+	([pkg, ver]) => (packageConfig.devDependencies as Record<string, string>)[pkg] === ver,
 );
 const versionFilePath = resolve(import.meta.dirname, '..', '.stylelint-version');
 

--- a/scripts/test-node-versions.mts
+++ b/scripts/test-node-versions.mts
@@ -1,9 +1,7 @@
-'use strict';
+import assert from 'node:assert';
+import process from 'node:process';
 
-const assert = require('node:assert');
-const process = require('node:process');
-
-const packageJson = require('../package.json');
+import packageJson from '../package.json' with { type: 'json' };
 
 const nodeVersion = process.version.slice(1); // trim the 'v' from the version
 

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -5,6 +5,6 @@
 		"noEmit": true,
 		"skipLibCheck": true
 	},
-	"include": ["*.js", ".*.js", "package.json", "scripts/**/*", "scripts/**/*.*.js"],
+	"include": ["*.js", ".*.js", "package.json", "scripts/**/*"],
 	"exclude": ["**/coverage"]
 }


### PR DESCRIPTION
Now that the version of Node.js used supports TypeScript natively, standardize everything to TypeScript.