### PR TITLE
chore: rerelease language server

### DIFF
--- a/.changeset/open-carrots-beg.md
+++ b/.changeset/open-carrots-beg.md
@@ -1,0 +1,7 @@
+---
+"@stylelint/language-server": major
+---
+
+pr: #870
+
+Added: initial release of the Stylelint language server

--- a/cspell.config.js
+++ b/cspell.config.js
@@ -5,7 +5,15 @@ const config = {
 	version: '0.2',
 	language: 'en-GB',
 	files: ['**/*.{js,mjs,cjs,ts,mts,cts,json,md,yml,css,scss}'],
-	ignorePaths: ['**/node_modules', '**/.yarn', '**/coverage', '.wireit', 'dist', 'build'],
+	ignorePaths: [
+		'**/node_modules',
+		'**/.yarn',
+		'**/coverage',
+		'.wireit',
+		'dist',
+		'build',
+		'**/CHANGELOG.md',
+	],
 	words: [
 		'Autofix',
 		'browserslist',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14703,7 +14703,7 @@
     },
     "packages/language-server": {
       "name": "@stylelint/language-server",
-      "version": "1.0.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "fast-diff": "^1.3.0",

--- a/packages/language-server/CHANGELOG.md
+++ b/packages/language-server/CHANGELOG.md
@@ -1,5 +1,1 @@
 # Changelog
-
-## 1.0.0 - 2026-03-18
-
-- Added: initial release of the Stylelint language server ([#870](https://github.com/stylelint/vscode-stylelint/pull/870)) ([@adalinesimonian](https://github.com/adalinesimonian)).

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylelint/language-server",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Stylelint Language Server Protocol implementation",
   "keywords": [
     "stylelint",
@@ -82,5 +82,8 @@
   },
   "engines": {
     "node": ">=22.17.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This should fix the publish settings and let the release process give it another go at releasing 1.0.0 of the language server.