### PR TITLE
chore: fix duplicate date in changelog

### DIFF
--- a/.changeset/rewrite-changelog.mts
+++ b/.changeset/rewrite-changelog.mts
@@ -52,7 +52,7 @@ for (const line of currentLines) {
 
 	if (line.startsWith('## ')) {
 		if (!latestVersion) {
-			latestVersion = line.replace('## ', '');
+			latestVersion = line.replace('## ', '').replace(/ - \d{4}-\d{2}-\d{2}$/, '');
 			newLines.push(`## ${latestVersion} - ${today}`);
 			continue;
 		} else {


### PR DESCRIPTION
This is also what's causing the other package to get picked up as changed, since we check the change logs for diffs to know what to release.