### PR TITLE
docs: document Stylelint version support policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ If you want a quick overview, the [organization](#1-how-the-project-is-organised
   - [8.5 Letting the runtime discover the handler](#85-letting-the-runtime-discover-the-handler)
   - [8.6 Adding the extension command](#86-adding-the-extension-command)
   - [8.7 Testing the service](#87-testing-the-service)
+- [9. Stylelint version support policy](#9-stylelint-version-support-policy)
 
 ## 1. How the project is organised
 
@@ -661,3 +662,19 @@ With the test in place, `node --run test:unit -- packages/language-server/src/se
 This worked example is intentionally small, but the same wiring pattern applies to more complex features. You define or reuse tokens, decorate your service with `@inject` and optionally `@lspService`, register it in a module, and then integrate it with the extension via commands or notifications.
 
 If you glance back at sections 3 and 4 now, you should recognise the pieces you just used: a service class, a module, LSP decorators, and a small test container.
+
+## 9. Stylelint version support policy
+
+The extension supports all Stylelint versions that work without active maintenance burden. We drop support only when maintaining compatibility causes bugs, blocks features, or adds meaningful complexity.
+
+When evaluating whether to drop support for a version, consider whether it:
+
+- Requires workarounds that increase code complexity beyond a reasonable threshold.
+- Causes numerous test failures unrelated to the version's own behaviour.
+- Prevents adoption of new Stylelint APIs.
+- Requires compromises in the API surface or UX for users on current versions.
+- Has known security vulnerabilities that would require unsafe patterns to support.
+
+When we decide to drop support for a version, we provide at least 3 months' notice with a deprecation warning before removal. This gives users a predictable window to migrate.
+
+For more context on this policy, see [the version support policy discussion](https://github.com/stylelint/vscode-stylelint/issues/829).

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -1,0 +1,60 @@
+# Migration Guide
+
+## From vscode-stylelint 1.x to 2.x
+
+vscode-stylelint 2.x is the first version of the extension to support Stylelint 17.x. It's also backwards compatible with older version of Stylelint, down to 14.x.
+
+It requires VS Code version 1.103.0 or later.
+
+## From vscode-stylelint 0.x to 1.x
+
+### Stylelint 13.x and Prior is No Longer Supported
+
+> See also: [Stylelint 14 migration guide](https://github.com/stylelint/stylelint/blob/main/docs/migration-guide/to-14.md)
+
+vscode-stylelint 1.x expects to use Stylelint 14 at minimum. Usage with prior versions of Stylelint is no longer supported. While older versions may continue to work for a while, you may encounter unexpected behaviour. You should upgrade your copy of Stylelint to version 14 or later for the best experience.
+
+The `syntax` and `configOverrides` options have been removed from Stylelint 14 and this extension. See the [following section](#%EF%B8%8F-only-css-and-postcss-are-validated-by-default) for information on how to use different syntaxes.
+
+### Stylelint is No Longer Bundled
+
+Unlike 0.x, 1.x no longer provides a copy of Stylelint bundled with the extension. Bundling Stylelint brought up many unwanted side effects and significantly increased the extension's size.
+
+Starting with 1.x, vscode-stylelint will depend on having a copy of Stylelint installed in the open workspace (recommended) or globally (not recommended). If the extension doesn't seem to be linting any documents, make sure you have Stylelint installed.
+
+### Only CSS and PostCSS are Validated by Default
+
+The 0.x versions of this extension, which used Stylelint 13.x and prior, supported validating many different languages out of the box without any additional configuration. However, this added a lot of complexity and resulted in many cases of unwanted or unexpected behaviour.
+
+In current versions of the extension, the extension only supports validating CSS and PostCSS out of the box and requires additional configuration to validate other languages. You will need to:
+
+1. Install the PostCSS syntax for the language you want to validate into your workspace, e.g. [postcss-scss](https://www.npmjs.com/package/postcss-scss).
+   <!-- prettier-ignore -->
+   <!-- cspell:disable-next-line -->
+1. Configure Stylelint to use the syntax by providing the module name in the [`customSyntax`](https://stylelint.io/user-guide/usage/options/#customsyntax) option using overrides (or use the [corresponding option](#stylelintcustomsyntax) in this extension's settings).
+
+   Example Stylelint config:
+
+   ```js
+   module.exports = {
+     overrides: [
+       {
+         files: ["**/*.scss"],
+         customSyntax: "postcss-scss"
+       }
+     ]
+   };
+   ```
+
+    <!-- prettier-ignore -->
+    <!-- cspell:disable-next-line -->
+
+1. Add the [language identifiers](https://code.visualstudio.com/docs/languages/overview#_language-identifier) for the documents you want to validate to the extension's workspace or user settings using the [`stylelint.validate`](#stylelintvalidate) option.
+
+   Example VS Code config:
+
+   ```json
+   {
+     "stylelint.validate": ["css", "scss"]
+   }
+   ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The official [Visual Studio Code](https://code.visualstudio.com/) extension for 
 
 <img width="449" alt="Screenshot of Stylelint errors displayed in VS Code" src="https://raw.githubusercontent.com/stylelint/vscode-stylelint/main/media/screenshot.png">
 
+_Currently tested against Stylelint 14-17. Untested versions may still work, but are not guaranteed to do so. See [Stylelint Version Support](#stylelint-version-support) for details._
+
 <!-- cspell:disable-next-line -->
 
 **Table of Contents**
@@ -17,9 +19,8 @@ The official [Visual Studio Code](https://code.visualstudio.com/) extension for 
   - [Actions](#actions)
   - [Problem Matchers](#problem-matchers)
   - [Extension Settings](#extension-settings)
+- [Stylelint Version Support](#stylelint-version-support)
 - [Migrating](#migrating)
-  - [From vscode-stylelint 1.x](#from-vscode-stylelint-1x)
-  - [From vscode-stylelint 0.x/Stylelint 13.x](#from-vscode-stylelint-0xstylelint-13x)
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
 - [Licence](#licence)
@@ -403,68 +404,15 @@ Sets the Stylelint [`reportNeedlessDisables`](https://stylelint.io/user-guide/op
 
 Sets the Stylelint [`reportInvalidScopeDisables`](https://stylelint.io/user-guide/options/#reportinvalidscopedisables) option. If `true`, Stylelint reports errors for `stylelint-disable` comments referring to rules that don't exist within the configuration object.
 
+## Stylelint Version Support
+
+We support all Stylelint versions that work without active maintenance burden. We drop support when maintaining compatibility causes bugs, blocks features, or adds meaningful complexity. Versions not listed above as tested may still work but are not officially supported.
+
+When we do decide to drop support for a version, we will provide at least 3 months' notice with a deprecation warning before removal, giving users a predictable window to migrate.
+
 ## Migrating
 
-Migrating from previous major versions of the extension.
-
-### From vscode-stylelint 1.x
-
-vscode-stylelint 2.x is the first version of the extension to support Stylelint 17.x. It's also backwards compatible with older version of Stylelint, down to 14.x.
-
-It requires VS Code version 1.103.0 or later.
-
-### From vscode-stylelint 0.x/Stylelint 13.x
-
-#### Stylelint 13.x and Prior is No Longer Supported
-
-> See also: [Stylelint 14 migration guide](https://github.com/stylelint/stylelint/blob/main/docs/migration-guide/to-14.md)
-
-vscode-stylelint 1.x expects to use Stylelint 14 at minimum. Usage with prior versions of Stylelint is no longer supported. While older versions may continue to work for a while, you may encounter unexpected behaviour. You should upgrade your copy of Stylelint to version 14 or later for the best experience.
-
-The `syntax` and `configOverrides` options have been removed from Stylelint 14 and this extension. See the [following section](#%EF%B8%8F-only-css-and-postcss-are-validated-by-default) for information on how to use different syntaxes.
-
-#### Stylelint is No Longer Bundled
-
-Unlike 0.x, 1.x no longer provides a copy of Stylelint bundled with the extension. Bundling Stylelint brought up many unwanted side effects and significantly increased the extension's size.
-
-Starting with 1.x, vscode-stylelint will depend on having a copy of Stylelint installed in the open workspace (recommended) or globally (not recommended). If the extension doesn't seem to be linting any documents, make sure you have Stylelint installed.
-
-#### Only CSS and PostCSS are Validated by Default
-
-The 0.x versions of this extension, which used Stylelint 13.x and prior, supported validating many different languages out of the box without any additional configuration. However, this added a lot of complexity and resulted in many cases of unwanted or unexpected behaviour.
-
-In current versions of the extension, the extension only supports validating CSS and PostCSS out of the box and requires additional configuration to validate other languages. You will need to:
-
-1. Install the PostCSS syntax for the language you want to validate into your workspace, e.g. [postcss-scss](https://www.npmjs.com/package/postcss-scss).
-   <!-- prettier-ignore -->
-   <!-- cspell:disable-next-line -->
-1. Configure Stylelint to use the syntax by providing the module name in the [`customSyntax`](https://stylelint.io/user-guide/usage/options/#customsyntax) option using overrides (or use the [corresponding option](#stylelintcustomsyntax) in this extension's settings).
-
-   Example Stylelint config:
-
-   ```js
-   module.exports = {
-     overrides: [
-       {
-         files: ["**/*.scss"],
-         customSyntax: "postcss-scss"
-       }
-     ]
-   };
-   ```
-
-    <!-- prettier-ignore -->
-    <!-- cspell:disable-next-line -->
-
-1. Add the [language identifiers](https://code.visualstudio.com/docs/languages/overview#_language-identifier) for the documents you want to validate to the extension's workspace or user settings using the [`stylelint.validate`](#stylelintvalidate) option.
-
-   Example VS Code config:
-
-   ```json
-   {
-     "stylelint.validate": ["css", "scss"]
-   }
-   ```
+See the [migration guide](https://github.com/stylelint/vscode-stylelint/blob/main/MIGRATE.md) for instructions on how to migrate from older versions of the extension.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Resolves #829.

Add the documentation agreed on in #829. Move the migration docs to their own file as well, since they were cluttering up the readme with old info, and now we'll have a dedicated place for this information.