### PR TITLE
ci: only mark vscode-stylelint releases as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
           name: 'vscode-stylelint ${{ needs.detect.outputs.extension-version }}'
           body: ${{ steps.changelog.outputs.body }}
           files: '*.vsix'
+          make_latest: true
 
   release-server:
     needs: detect
@@ -162,3 +163,4 @@ jobs:
           tag_name: '@stylelint/language-server@${{ needs.detect.outputs.server-version }}'
           name: '@stylelint/language-server ${{ needs.detect.outputs.server-version }}'
           body: ${{ steps.changelog.outputs.body }}
+          make_latest: false


### PR DESCRIPTION
Otherwise depending on execution order the language server package ends up being the latest release, but really for "latest" in this repository most people are looking for the VS Code extension, not the language server package.