### PR TITLE
feat: status indicator

### DIFF
--- a/.changeset/breezy-badgers-cover.md
+++ b/.changeset/breezy-badgers-cover.md
@@ -1,0 +1,5 @@
+---
+"@stylelint/vscode-stylelint": minor
+---
+
+Added: Status indicator for Stylelint state and a command to open the Stylelint output panel

--- a/.changeset/four-seals-lick.md
+++ b/.changeset/four-seals-lick.md
@@ -1,0 +1,5 @@
+---
+"@stylelint/language-server": minor
+---
+
+Added: `stylelint/status` notification reporting whether the server ran successfully for a document

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The extension adds the following commands to the command palette:
 - `Lint Workspace Folder` - lint all matching files in a single workspace folder
 - `Clear All Problems` - clear all Stylelint diagnostics
 - `Restart Stylelint Server` - restart the Stylelint LSP and runtime server
+- `Show Output Channel` - open the Stylelint output panel
 
 ### Actions
 

--- a/package.json
+++ b/package.json
@@ -290,6 +290,11 @@
         "title": "Restart Stylelint Server",
         "category": "Stylelint",
         "command": "stylelint.restart"
+      },
+      {
+        "title": "Show Output Channel",
+        "category": "Stylelint",
+        "command": "stylelint.showOutputChannel"
       }
     ],
     "jsonValidation": [

--- a/packages/language-server/src/server/services/lsp/__tests__/validator.service.test.ts
+++ b/packages/language-server/src/server/services/lsp/__tests__/validator.service.test.ts
@@ -57,6 +57,7 @@ function createDiagnosticsConnectionStub(): DiagnosticsConnectionStub {
 
 			sendDiagnosticsCalls.push({ uri: params.uri, diagnostics: params.diagnostics });
 		},
+		sendNotification: async () => {},
 		window: {
 			showErrorMessage: async (message: string) => {
 				windowMessages.push(message);

--- a/packages/language-server/src/server/services/lsp/validator.service.ts
+++ b/packages/language-server/src/server/services/lsp/validator.service.ts
@@ -17,7 +17,7 @@ import {
 } from '../../decorators.js';
 import type { LintDiagnostics } from '../../stylelint/index.js';
 import { lspConnectionToken, textDocumentsToken, UriModuleToken } from '../../tokens.js';
-import { CommandId } from '../../types.js';
+import { CommandId, Status, StatusNotification } from '../../types.js';
 import { DocumentDiagnosticsService } from '../documents/document-diagnostics.service.js';
 import { type LoggingService, loggingServiceToken } from '../infrastructure/logging.service.js';
 import { StylelintRunnerService } from '../stylelint-runtime/stylelint-runner.service.js';
@@ -149,12 +149,14 @@ export class ValidatorLspService {
 			this.#diagnostics.set(document, result.diagnostics, result);
 			this.#publishedUris.add(document.uri);
 			this.#logger?.debug('Diagnostics sent', { uri: document.uri });
+			this.#sendStatusNotification(document.uri, Status.ok);
 		} catch (error) {
 			displayError(this.#connection, error);
 			this.#logger?.error('Failed to send diagnostics', {
 				uri: document.uri,
 				error,
 			});
+			this.#sendStatusNotification(document.uri, Status.error);
 		}
 	}
 
@@ -169,9 +171,16 @@ export class ValidatorLspService {
 		} catch (error) {
 			displayError(this.#connection, error);
 			this.#logger?.error('Error running lint', { uri: document.uri, error });
+			this.#sendStatusNotification(document.uri, Status.error);
 
 			return undefined;
 		}
+	}
+
+	#sendStatusNotification(uri: string, state: Status): void {
+		this.#connection.sendNotification(StatusNotification, { uri, state }).catch(() => {
+			// Best effort, ignore any errors since it's non-critical.
+		});
 	}
 
 	@notification(DidChangeWatchedFilesNotification.type)

--- a/packages/language-server/src/server/types.ts
+++ b/packages/language-server/src/server/types.ts
@@ -1,4 +1,5 @@
 import { CodeActionKind as VSCodeActionKind } from 'vscode-languageserver-types';
+import { NotificationType } from 'vscode-languageserver-protocol';
 import type stylelint from 'stylelint';
 import type { PackageManager } from './stylelint/index.js';
 
@@ -88,3 +89,29 @@ export interface PnPConfiguration {
 	registerPath: string;
 	loaderPath?: string;
 }
+
+/**
+ * Status of the Stylelint language server for a given document. Refers to the
+ * whether the server ran successfully, not lint diagnostic severity.
+ */
+export enum Status {
+	/** Stylelint ran without errors. */
+	ok = 1,
+	/** Reserved for future use. */
+	warn = 2,
+	/** Stylelint failed to run. */
+	error = 3,
+}
+
+/**
+ * Parameters sent from server to client to report per-document status.
+ */
+export type StatusParams = {
+	uri: string;
+	state: Status;
+};
+
+/**
+ * Notification type for per-document Stylelint status changes.
+ */
+export const StatusNotification = new NotificationType<StatusParams>('stylelint/status');

--- a/src/extension/__tests__/extension.test.ts
+++ b/src/extension/__tests__/extension.test.ts
@@ -7,6 +7,8 @@ import { extensionTokens } from '../di-tokens.js';
 type VSCodeWorkspace = (typeof import('vscode'))['workspace'];
 type VSCodeCommands = (typeof import('vscode'))['commands'];
 type VSCodeWindow = (typeof import('vscode'))['window'];
+type VSCodeLanguages = (typeof import('vscode'))['languages'];
+type VSCodeLanguageStatusSeverity = (typeof import('vscode'))['LanguageStatusSeverity'];
 type LanguageClientModule = typeof import('vscode-languageclient/node');
 type ExtensionToken = (typeof extensionTokens)[keyof typeof extensionTokens];
 type ExtensionOverrideEntry = [ExtensionToken, unknown];
@@ -24,6 +26,9 @@ const start = vi.fn();
 const stop = vi.fn();
 const dispose = vi.fn();
 const sendRequest = vi.fn();
+const onDidChangeState = vi.fn();
+const onNotification = vi.fn();
+const outputChannel = { show: vi.fn(), append: vi.fn(), appendLine: vi.fn(), dispose: vi.fn() };
 
 const mockExtensionContext = {
 	subscriptions: [],
@@ -32,6 +37,7 @@ const mockExtensionContext = {
 let mockWorkspace: VSCodeWorkspace;
 let mockCommands: VSCodeCommands;
 let mockWindow: VSCodeWindow;
+let mockLanguages: VSCodeLanguages;
 let mockLanguageClient: ReturnType<typeof vi.fn>;
 let languageClientInstance: LanguageClient;
 let moduleOverrides: Iterable<ExtensionOverrideEntry>;
@@ -87,6 +93,7 @@ describe('Extension entry point', () => {
 			createFileSystemWatcher: fileWatcherMock,
 			workspaceFolders: [],
 			onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+			onDidCloseTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
 		} as unknown as VSCodeWorkspace;
 
 		registerCommandMock = vi.fn();
@@ -105,13 +112,29 @@ describe('Extension entry point', () => {
 			showErrorMessage: showErrorMessageMock,
 			showInformationMessage: vi.fn(),
 			showWarningMessage: vi.fn(),
+			onDidChangeActiveTextEditor: vi.fn(() => ({ dispose: vi.fn() })),
 		} as unknown as VSCodeWindow;
+
+		mockLanguages = {
+			createLanguageStatusItem: vi.fn(() => ({
+				name: '',
+				text: '',
+				severity: 0,
+				detail: undefined,
+				command: undefined,
+				selector: [],
+				dispose: vi.fn(),
+			})),
+		} as unknown as VSCodeLanguages;
 
 		languageClientInstance = {
 			sendRequest,
 			start,
 			stop,
 			dispose,
+			onDidChangeState,
+			onNotification,
+			outputChannel,
 		} as unknown as LanguageClient;
 
 		// eslint-disable-next-line prefer-arrow-callback -- Must be constructable via `new`
@@ -126,11 +149,17 @@ describe('Extension entry point', () => {
 			[extensionTokens.workspace, mockWorkspace],
 			[extensionTokens.commands, mockCommands],
 			[extensionTokens.window, mockWindow],
+			[extensionTokens.languages, mockLanguages],
+			[
+				extensionTokens.languageStatusSeverity,
+				{ Information: 0, Warning: 1, Error: 2 } as unknown as VSCodeLanguageStatusSeverity,
+			],
 			[
 				extensionTokens.languageClientModule,
 				{
 					LanguageClient: mockLanguageClient as unknown as LanguageClientModule['LanguageClient'],
-				} as LanguageClientModule,
+					State: { Stopped: 1, Running: 2, Starting: 3 },
+				} as unknown as LanguageClientModule,
 			],
 		];
 
@@ -263,8 +292,9 @@ describe('Extension entry point', () => {
 		const { subscriptions } = mockExtensionContext;
 		const onDidChangeCfg = mockWorkspace.onDidChangeConfiguration as ReturnType<typeof vi.fn>;
 
-		// Called twice, once for restart settings handler, once for enable handler.
-		expect(onDidChangeCfg).toHaveBeenCalledTimes(2);
+		// Called three times: restart settings handler, enable handler, and
+		// validate change handler.
+		expect(onDidChangeCfg).toHaveBeenCalledTimes(3);
 
 		// The enable handler's disposable should be in subscriptions.
 		const enableHandlerDisposable = onDidChangeCfg.mock.results[1].value;

--- a/src/extension/di-tokens.ts
+++ b/src/extension/di-tokens.ts
@@ -14,5 +14,9 @@ export const extensionTokens = {
 	workspace: createToken<typeof vscode.workspace>('extension-workspace'),
 	commands: createToken<typeof vscode.commands>('extension-commands'),
 	window: createToken<typeof vscode.window>('extension-window'),
+	languages: createToken<typeof vscode.languages>('extension-languages'),
+	languageStatusSeverity: createToken<typeof vscode.LanguageStatusSeverity>(
+		'extension-language-status-severity',
+	),
 	languageClientModule: createToken<LanguageClientModule>('extension-language-client-module'),
 } as const;

--- a/src/extension/extension-runtime.service.ts
+++ b/src/extension/extension-runtime.service.ts
@@ -1,6 +1,12 @@
 // @no-unit-test -- Relies on VS Code runtime objects and language client side-effects covered by integration tests.
 
-import type { Disposable, ExtensionContext, WorkspaceFolder } from 'vscode';
+import type {
+	Disposable,
+	DocumentFilter,
+	ExtensionContext,
+	LanguageStatusItem,
+	WorkspaceFolder,
+} from 'vscode';
 import type { LanguageClient } from 'vscode-languageclient/node';
 
 import { inject } from '@stylelint/language-server/di';
@@ -8,9 +14,16 @@ import {
 	runtimeService,
 	type RuntimeLifecycleParticipant,
 } from '@stylelint/language-server/di/runtime';
-import { CommandId } from '@stylelint/language-server';
+import { CommandId, Status, StatusNotification } from '@stylelint/language-server';
 import { extensionTokens } from './di-tokens.js';
-import type { VSCodeCommands, VSCodeWindow, VSCodeWorkspace } from './services/environment.js';
+import type {
+	LanguageClientModule,
+	VSCodeCommands,
+	VSCodeLanguages,
+	VSCodeLanguageStatusSeverity,
+	VSCodeWindow,
+	VSCodeWorkspace,
+} from './services/environment.js';
 import { LanguageClientService } from './services/language-client.service.js';
 
 const workspaceNotificationError =
@@ -24,6 +37,9 @@ const workspaceNotificationError =
 		extensionTokens.commands,
 		extensionTokens.workspace,
 		extensionTokens.context,
+		extensionTokens.languages,
+		extensionTokens.languageStatusSeverity,
+		extensionTokens.languageClientModule,
 	],
 })
 export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
@@ -32,11 +48,20 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 	readonly #commands: VSCodeCommands;
 	readonly #workspace: VSCodeWorkspace;
 	readonly #context: ExtensionContext;
+	readonly #languages: VSCodeLanguages;
+	readonly #languageStatusSeverity: VSCodeLanguageStatusSeverity;
+	readonly #languageClientModule: LanguageClientModule;
 	readonly #commandDisposables: Disposable[] = [];
+	readonly #documentStatus = new Map<string, Status>();
 	#client: LanguageClient;
 	#settingMonitorDisposable?: Disposable;
 	#configChangeDisposable?: Disposable;
+	#languageStatus?: LanguageStatusItem;
+	#activeEditorDisposable?: Disposable;
+	#closeDocumentDisposable?: Disposable;
+	#validateChangeDisposable?: Disposable;
 	#settingSnapshots = new Map<string, string>();
+	#serverRunning: boolean | undefined;
 	#needsRecreate = false;
 
 	constructor(
@@ -45,18 +70,25 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 		commands: VSCodeCommands,
 		workspace: VSCodeWorkspace,
 		context: ExtensionContext,
+		languages: VSCodeLanguages,
+		languageStatusSeverity: VSCodeLanguageStatusSeverity,
+		languageClientModule: LanguageClientModule,
 	) {
 		this.#languageClientService = languageClientService;
 		this.#window = window;
 		this.#commands = commands;
 		this.#workspace = workspace;
 		this.#context = context;
+		this.#languages = languages;
+		this.#languageStatusSeverity = languageStatusSeverity;
+		this.#languageClientModule = languageClientModule;
 		this.#client = this.#languageClientService.createClient();
 	}
 
 	async onStart(): Promise<void> {
 		this.#registerCommands();
 		this.#registerConfigurationChangeHandler();
+		this.#createLanguageStatusItem();
 
 		this.#settingMonitorDisposable = this.#createEnableSettingHandler();
 		this.#context.subscriptions.push(this.#settingMonitorDisposable);
@@ -72,6 +104,46 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 	async onShutdown(): Promise<void> {
 		await this.#disposeClient();
 		this.#disposeCommands();
+
+		if (this.#languageStatus) {
+			try {
+				this.#languageStatus.dispose();
+			} catch {
+				// Best-effort cleanup.
+			}
+
+			this.#languageStatus = undefined;
+		}
+
+		if (this.#activeEditorDisposable) {
+			try {
+				this.#activeEditorDisposable.dispose();
+			} catch {
+				// Best-effort cleanup.
+			}
+
+			this.#activeEditorDisposable = undefined;
+		}
+
+		if (this.#closeDocumentDisposable) {
+			try {
+				this.#closeDocumentDisposable.dispose();
+			} catch {
+				// Best-effort cleanup.
+			}
+
+			this.#closeDocumentDisposable = undefined;
+		}
+
+		if (this.#validateChangeDisposable) {
+			try {
+				this.#validateChangeDisposable.dispose();
+			} catch {
+				// Best-effort cleanup.
+			}
+
+			this.#validateChangeDisposable = undefined;
+		}
 
 		if (this.#configChangeDisposable) {
 			try {
@@ -95,6 +167,7 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 	}
 
 	async #startClient(): Promise<void> {
+		this.#registerClientHandlers();
 		await this.#client.start();
 	}
 
@@ -246,10 +319,18 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 			},
 		);
 
+		const showOutputChannelDisposable = this.#commands.registerCommand(
+			'stylelint.showOutputChannel',
+			() => {
+				this.#client.outputChannel.show();
+			},
+		);
+
 		this.#registerDisposable(executeAutofixDisposable);
 		this.#registerDisposable(restartDisposable);
 		this.#registerDisposable(lintAllFilesDisposable);
 		this.#registerDisposable(lintWorkspaceFolderDisposable);
+		this.#registerDisposable(showOutputChannelDisposable);
 	}
 
 	#registerConfigurationChangeHandler(): void {
@@ -374,6 +455,115 @@ export class ExtensionRuntimeService implements RuntimeLifecycleParticipant {
 		await this.#window.showErrorMessage(
 			`Stylelint: ${error instanceof Error ? error.message : String(error)}`,
 		);
+	}
+
+	#createLanguageStatusItem(): void {
+		this.#languageStatus = this.#languages.createLanguageStatusItem(
+			'stylelint.languageStatus',
+			this.#buildLanguageSelector(),
+		);
+		this.#languageStatus.name = 'Stylelint';
+		this.#languageStatus.text = 'Stylelint';
+		this.#languageStatus.command = {
+			title: 'Open Stylelint Output',
+			command: 'stylelint.showOutputChannel',
+		};
+		this.#context.subscriptions.push(this.#languageStatus);
+
+		this.#activeEditorDisposable = this.#window.onDidChangeActiveTextEditor(() => {
+			this.#updateStatusBar();
+		});
+		this.#context.subscriptions.push(this.#activeEditorDisposable);
+
+		this.#closeDocumentDisposable = this.#workspace.onDidCloseTextDocument((document) => {
+			this.#documentStatus.delete(document.uri.toString());
+			this.#updateStatusBar();
+		});
+		this.#context.subscriptions.push(this.#closeDocumentDisposable);
+
+		this.#validateChangeDisposable = this.#workspace.onDidChangeConfiguration((event) => {
+			if (event.affectsConfiguration('stylelint.validate') && this.#languageStatus) {
+				this.#languageStatus.selector = this.#buildLanguageSelector();
+			}
+		});
+		this.#context.subscriptions.push(this.#validateChangeDisposable);
+	}
+
+	#registerClientHandlers(): void {
+		const { State } = this.#languageClientModule;
+
+		this.#client.onDidChangeState((event) => {
+			if (event.newState === State.Running) {
+				this.#serverRunning = true;
+			} else if (event.newState === State.Stopped) {
+				this.#serverRunning = false;
+			} else {
+				this.#serverRunning = undefined;
+			}
+
+			this.#updateStatusBar();
+		});
+
+		this.#client.onNotification(StatusNotification, (params) => {
+			this.#documentStatus.set(params.uri, params.state);
+			this.#updateStatusBar();
+		});
+	}
+
+	#buildLanguageSelector(): DocumentFilter[] {
+		const languages = this.#workspace
+			.getConfiguration('stylelint')
+			.get<string[]>('validate', ['css', 'postcss']);
+
+		return languages.map((language) => ({ language }));
+	}
+
+	#updateStatusBar(): void {
+		if (!this.#languageStatus) {
+			return;
+		}
+
+		const LanguageStatusSeverity = this.#languageStatusSeverity;
+
+		if (this.#serverRunning === false) {
+			this.#languageStatus.severity = LanguageStatusSeverity.Error;
+			this.#languageStatus.detail = 'Server stopped';
+
+			return;
+		}
+
+		if (this.#serverRunning === undefined) {
+			this.#languageStatus.severity = LanguageStatusSeverity.Information;
+			this.#languageStatus.detail = 'Server starting…';
+
+			return;
+		}
+
+		const activeUri = this.#window.activeTextEditor?.document.uri.toString();
+
+		if (!activeUri) {
+			this.#languageStatus.severity = LanguageStatusSeverity.Information;
+			this.#languageStatus.detail = undefined;
+
+			return;
+		}
+
+		const status = this.#documentStatus.get(activeUri);
+
+		switch (status) {
+			case Status.warn:
+				this.#languageStatus.severity = LanguageStatusSeverity.Warning;
+				break;
+			case Status.error:
+				this.#languageStatus.severity = LanguageStatusSeverity.Error;
+				break;
+			case Status.ok:
+			case undefined:
+				this.#languageStatus.severity = LanguageStatusSeverity.Information;
+				break;
+		}
+
+		this.#languageStatus.detail = undefined;
 	}
 
 	#isClientInactiveError(error: unknown): boolean {

--- a/src/extension/platform.module.ts
+++ b/src/extension/platform.module.ts
@@ -20,6 +20,11 @@ export function createExtensionPlatformModule(context: ExtensionContext): Module
 			provideValue(extensionTokens.workspace, () => getVsCodeModule().workspace),
 			provideValue(extensionTokens.commands, () => getVsCodeModule().commands),
 			provideValue(extensionTokens.window, () => getVsCodeModule().window),
+			provideValue(extensionTokens.languages, () => getVsCodeModule().languages),
+			provideValue(
+				extensionTokens.languageStatusSeverity,
+				() => getVsCodeModule().LanguageStatusSeverity,
+			),
 			provideValue(extensionTokens.languageClientModule, () => getLanguageClientModule()),
 			provideValue(extensionTokens.serverModulePath, () => resolveServerModulePath()),
 		],

--- a/src/extension/services/environment.ts
+++ b/src/extension/services/environment.ts
@@ -37,6 +37,8 @@ export function getLanguageClientModule(): LanguageClientModule {
 export type VSCodeWorkspace = VSCodeModule['workspace'];
 export type VSCodeCommands = VSCodeModule['commands'];
 export type VSCodeWindow = VSCodeModule['window'];
+export type VSCodeLanguages = VSCodeModule['languages'];
+export type VSCodeLanguageStatusSeverity = VSCodeModule['LanguageStatusSeverity'];
 
 /**
  * Resolves the path to the compiled language server entry point.


### PR DESCRIPTION
Until now there hasn't been a way to see Stylelint's state at a glance. Error popups surface when things went wrong, but there is nothing persistent in the UI showing whether Stylelint is running, has failed for a document, or is even active. Here I add a language status indicator that shows Stylelint's state persistently in the status area, similar to ESLint's.

The language server now sends a `stylelint/status` notification after each validation attempt. On the extension side, this drives a `LanguageStatusItem` scoped to the language IDs from `stylelint.validate`. It reflects both the server lifecycle and per-document status from the notification. It provides a convenient link that opens the output panel via a new `stylelint.showOutputChannel` command, which can also be run on its own, manually, if the user so chooses to.

<img width="544" height="114" alt="Screenshot of OK state" src="https://github.com/user-attachments/assets/675bd31e-bdc4-476a-8b8a-84d8558a0d55" />

<img width="608" height="149" alt="Screenshot of error state" src="https://github.com/user-attachments/assets/df969ea5-32ef-4743-80e9-72af61db3193" />