### PR TITLE
fix: worker-related bugs preventing crash recovery

### DIFF
--- a/.changeset/fix-crash-counting-dedup.md
+++ b/.changeset/fix-crash-counting-dedup.md
@@ -1,0 +1,6 @@
+---
+"@stylelint/language-server": patch
+"@stylelint/vscode-stylelint": patch
+---
+
+Fixed: Workers not recovering from crashes due to counting the same crash multiple times when multiple requests are pending

--- a/.changeset/fix-worker-handling-windows.md
+++ b/.changeset/fix-worker-handling-windows.md
@@ -1,0 +1,6 @@
+---
+"@stylelint/language-server": patch
+"@stylelint/vscode-stylelint": patch
+---
+
+Fixed: Duplicate workers being started due to drive letter case sensitivity on Windows

--- a/packages/language-server/src/server/services/stylelint-runtime/__tests__/worker-registry.service.test.ts
+++ b/packages/language-server/src/server/services/stylelint-runtime/__tests__/worker-registry.service.test.ts
@@ -216,17 +216,23 @@ describe('WorkerRegistryService', () => {
 
 		try {
 			const worker = createMockWorker();
-			const crashError = createCrashError('/workspace');
 			const { registry } = createRegistry([worker]);
 			const context: WorkerContext = {
 				workspaceFolder: '/workspace',
 				workerRoot: '/workspace',
 			};
 
-			worker.lint.mockRejectedValue(crashError);
+			// Creating a new error per call simulates separate crash events.
+			worker.lint.mockImplementation(() => {
+				throw createCrashError('/workspace');
+			});
 
-			await expect(registry.runWithWorker(context, executeLint)).rejects.toBe(crashError);
-			await expect(registry.runWithWorker(context, executeLint)).rejects.toBe(crashError);
+			await expect(registry.runWithWorker(context, executeLint)).rejects.toBeInstanceOf(
+				StylelintWorkerCrashedError,
+			);
+			await expect(registry.runWithWorker(context, executeLint)).rejects.toBeInstanceOf(
+				StylelintWorkerCrashedError,
+			);
 
 			const suppressionError = (await registry
 				.runWithWorker(context, executeLint)
@@ -244,7 +250,9 @@ describe('WorkerRegistryService', () => {
 
 			registry.notifyWorkspaceActivity('/workspace');
 
-			await expect(registry.runWithWorker(context, executeLint)).rejects.toBe(crashError);
+			await expect(registry.runWithWorker(context, executeLint)).rejects.toBeInstanceOf(
+				StylelintWorkerCrashedError,
+			);
 		} finally {
 			vi.useRealTimers();
 		}
@@ -268,8 +276,12 @@ describe('WorkerRegistryService', () => {
 				workerRoot: workspaceB,
 			};
 
-			workerA.lint.mockRejectedValue(createCrashError(workspaceA));
-			workerB.lint.mockRejectedValue(createCrashError(workspaceB));
+			workerA.lint.mockImplementation(() => {
+				throw createCrashError(workspaceA);
+			});
+			workerB.lint.mockImplementation(() => {
+				throw createCrashError(workspaceB);
+			});
 
 			const expectedErrors = [
 				StylelintWorkerCrashedError,
@@ -303,6 +315,36 @@ describe('WorkerRegistryService', () => {
 			expect(suppressedB.notifyUser).toBe(false);
 		} finally {
 			vi.useRealTimers();
+		}
+	});
+
+	test('counts a single crash only once even when multiple pending requests are rejected with the same error', async () => {
+		const worker = createMockWorker();
+		const { registry } = createRegistry([worker]);
+		const context: WorkerContext = {
+			workspaceFolder: '/workspace',
+			workerRoot: '/workspace',
+		};
+
+		// Simulate a worker crash that rejects multiple pending requests with
+		// the same error object. This is what happens when a child exits while
+		// several requests are in flight.
+		const sharedCrashError = createCrashError('/workspace');
+
+		worker.lint.mockRejectedValue(sharedCrashError);
+
+		// Fire three concurrent requests that all get the same crash error.
+		const results = await Promise.allSettled([
+			registry.runWithWorker(context, executeLint),
+			registry.runWithWorker(context, executeLint),
+			registry.runWithWorker(context, executeLint),
+		]);
+
+		// All three should be rejected with the original crash error, not a
+		// suppression error, because only one crash should have been counted.
+		for (const result of results) {
+			expect(result.status).toBe('rejected');
+			expect((result as PromiseRejectedResult).reason).toBe(sharedCrashError);
 		}
 	});
 });

--- a/packages/language-server/src/server/services/stylelint-runtime/worker-registry.service.ts
+++ b/packages/language-server/src/server/services/stylelint-runtime/worker-registry.service.ts
@@ -33,6 +33,7 @@ type WorkerHealthState = {
 	consecutiveCrashes: number;
 	cooldownExpiresAt?: number;
 	lastCrashError?: StylelintWorkerCrashedError;
+	lastHandledCrashError?: StylelintWorkerCrashedError;
 	lastNotificationAt?: number;
 };
 
@@ -235,6 +236,7 @@ export class WorkerRegistryService {
 		state.consecutiveCrashes = 0;
 		state.cooldownExpiresAt = undefined;
 		state.lastCrashError = undefined;
+		state.lastHandledCrashError = undefined;
 		state.lastNotificationAt = undefined;
 	}
 
@@ -244,7 +246,13 @@ export class WorkerRegistryService {
 		state: WorkerHealthState,
 		error: StylelintWorkerCrashedError,
 	): Error {
-		state.consecutiveCrashes += 1;
+		// When a worker exits with multiple pending requests, the same error
+		// object is used to reject every promise. Only count the crash once.
+		if (state.lastHandledCrashError !== error) {
+			state.consecutiveCrashes += 1;
+			state.lastHandledCrashError = error;
+		}
+
 		state.lastCrashError = error;
 
 		if (state.consecutiveCrashes < maxConsecutiveCrashes) {
@@ -283,6 +291,7 @@ export class WorkerRegistryService {
 		if (now >= cooldown) {
 			state.cooldownExpiresAt = undefined;
 			state.consecutiveCrashes = 0;
+			state.lastHandledCrashError = undefined;
 			state.lastNotificationAt = undefined;
 
 			return undefined;
@@ -352,6 +361,7 @@ export class WorkerRegistryService {
 
 		state.cooldownExpiresAt = undefined;
 		state.consecutiveCrashes = 0;
+		state.lastHandledCrashError = undefined;
 		state.lastNotificationAt = undefined;
 
 		return true;

--- a/packages/language-server/src/server/utils/__tests__/fs.test.ts
+++ b/packages/language-server/src/server/utils/__tests__/fs.test.ts
@@ -21,4 +21,20 @@ describe('normalizeFsPath', () => {
 			'C:\\Users\\stylelint\\project',
 		);
 	});
+
+	it('uppercases a lowercase Windows drive letter', () => {
+		expect(normalizeFsPath('c:\\Users\\stylelint', 'win32')).toBe('C:\\Users\\stylelint');
+	});
+
+	it('keeps an uppercase Windows drive letter unchanged', () => {
+		expect(normalizeFsPath('C:\\Users\\stylelint', 'win32')).toBe('C:\\Users\\stylelint');
+	});
+
+	it('uppercases drive letter when also replacing forward slashes', () => {
+		expect(normalizeFsPath('e:/vscode-stylelint', 'win32')).toBe('E:\\vscode-stylelint');
+	});
+
+	it('does not modify non-drive-letter paths on Windows', () => {
+		expect(normalizeFsPath('\\\\server\\share', 'win32')).toBe('\\\\server\\share');
+	});
 });

--- a/packages/language-server/src/server/utils/fs.ts
+++ b/packages/language-server/src/server/utils/fs.ts
@@ -11,5 +11,15 @@ export function normalizeFsPath(
 		return undefined;
 	}
 
-	return platform === 'win32' ? value.replace(/\//gu, '\\') : value;
+	if (platform !== 'win32') {
+		return value;
+	}
+
+	let result = value.replace(/\//gu, '\\');
+
+	if (/^[a-z]:\\/u.test(result)) {
+		result = result[0].toUpperCase() + result.slice(1);
+	}
+
+	return result;
 }


### PR DESCRIPTION
My investigation in #890 revealed that the flakiness we've been seeing in the Windows end-to-end tests is actually surfacing a couple real bugs, not just test flakiness.

## Bug 1: Drive letter case sensitivity on Windows

The language server tracks worker processes in a map keyed by file path. On Windows, different VS Code APIs can report the same path with different drive letter casing. One caller sends `e:\project`, another sends `E:\project`. The `normalizeFsPath` utility only converts forward slashes to backslashes, but doesn't normalize the drive letter. So, the registry treats these as two different workspaces and spawns two independent worker processes for the same project, each with its own independent crash counter. When the crash recovery logic checks whether the threshold was hit, it looks at the wrong counter, the one with the drive letter cased differently, so recovery never kicks in correctly.

`normalizeFsPath` now uppercases lowercase drive letters when running on Windows, i.e. normalizing `e:\foo` to `E:\foo`. This way, `e:\project` and `E:\project` always resolve to the same worker record.

## Bug 2: One crash counting as many

When a worker process exits, it has to reject every in-flight request. The exit handler in worker-process.ts creates one `StylelintWorkerCrashedError` and passes that same object to every pending promise's `reject` callback. Each of those rejected promises bubbles up through its own `runWithWorker` call, hits the `catch` block, and calls `#handleWorkerCrash`, which increments `consecutiveCrashes`. So if a worker has 4 pending lint requests when it crashes, the crash counter jumps from 0 to 4 in one shot. The threshold is 3, meaning a single crash with enough concurrent requests immediately triggers the 30-second cooldown.

`#handleWorkerCrash` now tracks the last error object it counted by reference via `lastHandledCrashError`. When multiple `runWithWorker` calls report the same error object, which is exactly what happens when one exit rejects N promises, only the first one increments the counter, guaranteeing we only treat a single crash as a single crash, not as multiple.