### PR TITLE
perf: deduplicate concurrent environment key stats

### DIFF
--- a/.changeset/early-camels-tap.md
+++ b/.changeset/early-camels-tap.md
@@ -1,0 +1,6 @@
+---
+"@stylelint/language-server": patch
+"@stylelint/vscode-stylelint": patch
+---
+
+Fixed: redundant filesystem stat calls when linting multiple open documents simultaneously

--- a/packages/language-server/src/server/services/stylelint-runtime/__tests__/worker-environment.service.test.ts
+++ b/packages/language-server/src/server/services/stylelint-runtime/__tests__/worker-environment.service.test.ts
@@ -104,4 +104,25 @@ describe('WorkerEnvironmentService', () => {
 
 		expect(initialKey).not.toBe(updatedKey);
 	});
+
+	test('deduplicates concurrent requests for the same inputs', async () => {
+		const workspaceRoot = path.resolve('/workspace');
+		const stylelintRoot = path.join(workspaceRoot, 'node_modules/stylelint');
+		const stylelintPath = path.join(stylelintRoot, 'index.js');
+		const { service, stat } = createService(
+			{
+				[path.join(workspaceRoot, 'package.json')]: 100,
+				[stylelintPath]: 300,
+				[path.join(stylelintRoot, 'package.json')]: 400,
+			},
+			stylelintRoot,
+		);
+
+		const input = { workerRoot: workspaceRoot, stylelintPath };
+
+		const [first, second] = await Promise.all([service.createKey(input), service.createKey(input)]);
+
+		expect(first).toBe(second);
+		expect(stat).toHaveBeenCalledTimes(7);
+	});
 });

--- a/packages/language-server/src/server/services/stylelint-runtime/worker-environment.service.ts
+++ b/packages/language-server/src/server/services/stylelint-runtime/worker-environment.service.ts
@@ -24,6 +24,7 @@ export class WorkerEnvironmentService {
 	readonly #fs: FsModule;
 	readonly #path: PathModule;
 	readonly #packageRootService: PackageRootService;
+	readonly #inFlightRequests = new Map<string, Promise<string>>();
 
 	constructor(fsModule: FsModule, pathModule: PathModule, packageRootService: PackageRootService) {
 		this.#fs = fsModule;
@@ -32,6 +33,25 @@ export class WorkerEnvironmentService {
 	}
 
 	async createKey(input: EnvironmentKeyInput): Promise<string> {
+		const requestKey = this.#buildRequestKey(input);
+
+		let request = this.#inFlightRequests.get(requestKey);
+
+		if (!request) {
+			request = this.#computeKey(input);
+			this.#inFlightRequests.set(requestKey, request);
+		}
+
+		try {
+			return await request;
+		} finally {
+			if (this.#inFlightRequests.get(requestKey) === request) {
+				this.#inFlightRequests.delete(requestKey);
+			}
+		}
+	}
+
+	async #computeKey(input: EnvironmentKeyInput): Promise<string> {
 		const normalizedRoot = this.#normalizePath(input.workerRoot);
 		const resolvedStylelintPath = this.#resolveMaybeRelative(input.stylelintPath, normalizedRoot);
 		const stylelintManifest = await this.#resolveStylelintManifest(resolvedStylelintPath);
@@ -72,6 +92,14 @@ export class WorkerEnvironmentService {
 			`stylelintEntry:${stylelintEntry ?? '-'}`,
 			`stylelintPkg:${stylelintPackage ?? '-'}`,
 		].join('|');
+	}
+
+	#buildRequestKey(input: EnvironmentKeyInput): string {
+		const normalizedRoot = this.#normalizePath(input.workerRoot);
+		const resolvedStylelintPath = this.#resolveMaybeRelative(input.stylelintPath, normalizedRoot);
+		const pnpKey = resolvePnPConfigKey(input.pnpConfig);
+
+		return `${normalizedRoot}|${resolvedStylelintPath ?? '-'}|${pnpKey}`;
 	}
 
 	async #resolveStylelintManifest(stylelintPath: string | undefined): Promise<string | undefined> {


### PR DESCRIPTION
Deduplicate in-flight `fs.stat` calls to reduce FS I/O when linting multiple documents.