### PR TITLE
perf: don't crypto hash diagnostic keys

### DIFF
--- a/.changeset/twelve-banks-hang.md
+++ b/.changeset/twelve-banks-hang.md
@@ -1,0 +1,6 @@
+---
+"@stylelint/language-server": patch
+"@stylelint/vscode-stylelint": patch
+---
+
+Fixed: sped up building diagnostic lookup keys

--- a/packages/language-server/src/server/stylelint/process-linter-result.ts
+++ b/packages/language-server/src/server/stylelint/process-linter-result.ts
@@ -1,4 +1,3 @@
-import * as crypto from 'crypto';
 import type LSP from 'vscode-languageserver-protocol';
 import type { Logger } from 'winston';
 import type { RuleCustomization } from '../types.js';
@@ -17,18 +16,8 @@ import { warningToDiagnostic } from './warning-to-diagnostic.js';
  * Returns a unique key for a diagnostic.
  * @param diagnostic The diagnostic to get a key for.
  */
-function getDiagnosticKey(diagnostic: LSP.Diagnostic): string {
-	const range = diagnostic.range;
-	let message = '';
-
-	if (diagnostic.message) {
-		const hash = crypto.createHash('sha256');
-
-		hash.update(diagnostic.message);
-		message = hash.digest('base64');
-	}
-
-	return `[${range.start.line},${range.start.character},${range.end.line},${range.end.character}]-${diagnostic.code}-${message}`;
+function getDiagnosticKey({ range: { start, end }, code, message }: LSP.Diagnostic): string {
+	return `[${start.line},${start.character},${end.line},${end.character}]-${code}-${message}`;
 }
 
 /**


### PR DESCRIPTION
Remove the unnecessary and expensive hashing of diagnostic messages with `crypto`.

`Map`s can already handle strings of arbitrary length with good time complexity. Using `crypto` here provides no benefit, and only makes this process much slower. `crypto` is a Node.js binding to OpenSSL, which incurs significant overhead on each call. And, also, SHA-256 is not optimized for speed but security, which is irrelevant to the use case here.