### PR TITLE
perf: pre-compile rule customization patterns

### DIFF
--- a/.changeset/beige-cases-doubt.md
+++ b/.changeset/beige-cases-doubt.md
@@ -1,0 +1,6 @@
+---
+"@stylelint/language-server": patch
+"@stylelint/vscode-stylelint": patch
+---
+
+Fixed: reduced redundant regex compilation when processing severity customizations

--- a/packages/language-server/src/server/stylelint/__tests__/warning-to-diagnostic.test.ts
+++ b/packages/language-server/src/server/stylelint/__tests__/warning-to-diagnostic.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test } from 'vitest';
 import { DiagnosticSeverity } from 'vscode-languageserver-types';
 import type { Logger } from 'winston';
 import { RuleCustomization } from '../../types.js';
-import { warningToDiagnostic } from '../warning-to-diagnostic.js';
+import { compileRuleCustomizations, warningToDiagnostic } from '../warning-to-diagnostic.js';
 import { createTestLogger } from '../../../../../../test/helpers/test-logger.js';
 import type { Warning } from '../types.js';
 
@@ -117,7 +117,12 @@ describe('warningToDiagnostic', () => {
 			const warning = createWarning('color-named', 'error');
 			const customizations: RuleCustomization[] = [{ rule: 'color-named', severity: 'warn' }];
 
-			const diagnostic = warningToDiagnostic(warning, logger, undefined, customizations);
+			const diagnostic = warningToDiagnostic(
+				warning,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(diagnostic).not.toBeNull();
 			expect(diagnostic!.severity).toBe(DiagnosticSeverity.Warning);
@@ -127,7 +132,12 @@ describe('warningToDiagnostic', () => {
 			const warning = createWarning('color-named', 'error');
 			const customizations: RuleCustomization[] = [{ rule: 'color-*', severity: 'info' }];
 
-			const diagnostic = warningToDiagnostic(warning, logger, undefined, customizations);
+			const diagnostic = warningToDiagnostic(
+				warning,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(diagnostic).not.toBeNull();
 			expect(diagnostic!.severity).toBe(DiagnosticSeverity.Information);
@@ -137,7 +147,12 @@ describe('warningToDiagnostic', () => {
 			const warning = createWarning('color-named', 'error');
 			const customizations: RuleCustomization[] = [{ rule: 'color-named', severity: 'off' }];
 
-			const diagnostic = warningToDiagnostic(warning, logger, undefined, customizations);
+			const diagnostic = warningToDiagnostic(
+				warning,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(diagnostic).toBeNull();
 		});
@@ -146,7 +161,12 @@ describe('warningToDiagnostic', () => {
 			const warning = createWarning('color-named', 'error');
 			const customizations: RuleCustomization[] = [{ rule: 'color-named', severity: 'downgrade' }];
 
-			const diagnostic = warningToDiagnostic(warning, logger, undefined, customizations);
+			const diagnostic = warningToDiagnostic(
+				warning,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(diagnostic).not.toBeNull();
 			expect(diagnostic!.severity).toBe(DiagnosticSeverity.Warning);
@@ -156,7 +176,12 @@ describe('warningToDiagnostic', () => {
 			const warning = createWarning('color-named', 'warning');
 			const customizations: RuleCustomization[] = [{ rule: 'color-named', severity: 'upgrade' }];
 
-			const diagnostic = warningToDiagnostic(warning, logger, undefined, customizations);
+			const diagnostic = warningToDiagnostic(
+				warning,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(diagnostic).not.toBeNull();
 			expect(diagnostic!.severity).toBe(DiagnosticSeverity.Error);
@@ -166,7 +191,12 @@ describe('warningToDiagnostic', () => {
 			const warning = createWarning('color-named', 'warning');
 			const customizations: RuleCustomization[] = [{ rule: 'color-named', severity: 'downgrade' }];
 
-			const diagnostic = warningToDiagnostic(warning, logger, undefined, customizations);
+			const diagnostic = warningToDiagnostic(
+				warning,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(diagnostic).not.toBeNull();
 			expect(diagnostic!.severity).toBe(DiagnosticSeverity.Information);
@@ -176,7 +206,12 @@ describe('warningToDiagnostic', () => {
 			const warning = createWarning('color-named', 'error');
 			const customizations: RuleCustomization[] = [{ rule: 'color-named', severity: 'upgrade' }];
 
-			const diagnostic = warningToDiagnostic(warning, logger, undefined, customizations);
+			const diagnostic = warningToDiagnostic(
+				warning,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(diagnostic).not.toBeNull();
 			expect(diagnostic!.severity).toBe(DiagnosticSeverity.Error);
@@ -190,7 +225,12 @@ describe('warningToDiagnostic', () => {
 				{ rule: 'color-named', severity: 'warn' },
 			];
 
-			const diagnostic = warningToDiagnostic(warning, logger, undefined, customizations);
+			const diagnostic = warningToDiagnostic(
+				warning,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(diagnostic).not.toBeNull();
 			expect(diagnostic!.severity).toBe(DiagnosticSeverity.Warning);
@@ -200,7 +240,12 @@ describe('warningToDiagnostic', () => {
 			const warning = createWarning('color-named', 'error');
 			const customizations: RuleCustomization[] = [{ rule: 'font-family-*', severity: 'warn' }];
 
-			const diagnostic = warningToDiagnostic(warning, logger, undefined, customizations);
+			const diagnostic = warningToDiagnostic(
+				warning,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(diagnostic).not.toBeNull();
 			expect(diagnostic!.severity).toBe(DiagnosticSeverity.Error);
@@ -210,7 +255,12 @@ describe('warningToDiagnostic', () => {
 			const warning = createWarning('color-named', 'warning');
 			const customizations: RuleCustomization[] = [{ rule: 'font-family-*', severity: 'error' }];
 
-			const diagnostic = warningToDiagnostic(warning, logger, undefined, customizations);
+			const diagnostic = warningToDiagnostic(
+				warning,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(diagnostic).not.toBeNull();
 			expect(diagnostic!.severity).toBe(DiagnosticSeverity.Warning);
@@ -220,8 +270,18 @@ describe('warningToDiagnostic', () => {
 			const warningError = createWarning('color-named', 'error');
 			const warningWarn = createWarning('color-named', 'warning');
 
-			const diagnosticError = warningToDiagnostic(warningError, logger, undefined, []);
-			const diagnosticWarn = warningToDiagnostic(warningWarn, logger, undefined, []);
+			const diagnosticError = warningToDiagnostic(
+				warningError,
+				logger,
+				undefined,
+				compileRuleCustomizations([]),
+			);
+			const diagnosticWarn = warningToDiagnostic(
+				warningWarn,
+				logger,
+				undefined,
+				compileRuleCustomizations([]),
+			);
 
 			expect(diagnosticError).not.toBeNull();
 			expect(diagnosticError!.severity).toBe(DiagnosticSeverity.Error);
@@ -240,9 +300,24 @@ describe('warningToDiagnostic', () => {
 				{ rule: 'color-*', severity: 'warn' },
 			];
 
-			const diagnostic1 = warningToDiagnostic(warning1, logger, undefined, customizations);
-			const diagnostic2 = warningToDiagnostic(warning2, logger, undefined, customizations);
-			const diagnostic3 = warningToDiagnostic(warning3, logger, undefined, customizations);
+			const diagnostic1 = warningToDiagnostic(
+				warning1,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
+			const diagnostic2 = warningToDiagnostic(
+				warning2,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
+			const diagnostic3 = warningToDiagnostic(
+				warning3,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(diagnostic1).not.toBeNull();
 			expect(diagnostic1!.severity).toBe(DiagnosticSeverity.Warning);
@@ -260,8 +335,18 @@ describe('warningToDiagnostic', () => {
 
 			const customizations: RuleCustomization[] = [{ rule: '!color-named', severity: 'warn' }];
 
-			const diagnostic1 = warningToDiagnostic(warning1, logger, undefined, customizations);
-			const diagnostic2 = warningToDiagnostic(warning2, logger, undefined, customizations);
+			const diagnostic1 = warningToDiagnostic(
+				warning1,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
+			const diagnostic2 = warningToDiagnostic(
+				warning2,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			// color-named should NOT match.
 			expect(diagnostic1).not.toBeNull();
@@ -279,9 +364,24 @@ describe('warningToDiagnostic', () => {
 
 			const customizations: RuleCustomization[] = [{ rule: '!color-*', severity: 'info' }];
 
-			const diagnostic1 = warningToDiagnostic(warning1, logger, undefined, customizations);
-			const diagnostic2 = warningToDiagnostic(warning2, logger, undefined, customizations);
-			const diagnostic3 = warningToDiagnostic(warning3, logger, undefined, customizations);
+			const diagnostic1 = warningToDiagnostic(
+				warning1,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
+			const diagnostic2 = warningToDiagnostic(
+				warning2,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
+			const diagnostic3 = warningToDiagnostic(
+				warning3,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			// color-* rules should NOT match, keeping their original severity.
 			expect(diagnostic1).not.toBeNull();
@@ -300,8 +400,18 @@ describe('warningToDiagnostic', () => {
 
 			const customizations: RuleCustomization[] = [{ rule: '!color-*', severity: 'off' }];
 
-			const diagnostic1 = warningToDiagnostic(warning1, logger, undefined, customizations);
-			const diagnostic2 = warningToDiagnostic(warning2, logger, undefined, customizations);
+			const diagnostic1 = warningToDiagnostic(
+				warning1,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
+			const diagnostic2 = warningToDiagnostic(
+				warning2,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			// color-* rules should NOT match.
 			expect(diagnostic1).not.toBeNull();
@@ -319,7 +429,12 @@ describe('warningToDiagnostic', () => {
 				{ rule: 'font-*', severity: 'warn' },
 			];
 
-			const diagnostic = warningToDiagnostic(warning, logger, undefined, customizations);
+			const diagnostic = warningToDiagnostic(
+				warning,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(diagnostic).not.toBeNull();
 			expect(diagnostic!.severity).toBe(DiagnosticSeverity.Warning);
@@ -332,9 +447,24 @@ describe('warningToDiagnostic', () => {
 
 			const customizations: RuleCustomization[] = [{ rule: '!*-block-*', severity: 'info' }];
 
-			const diagnostic1 = warningToDiagnostic(warning1, logger, undefined, customizations);
-			const diagnostic2 = warningToDiagnostic(warning2, logger, undefined, customizations);
-			const diagnostic3 = warningToDiagnostic(warning3, logger, undefined, customizations);
+			const diagnostic1 = warningToDiagnostic(
+				warning1,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
+			const diagnostic2 = warningToDiagnostic(
+				warning2,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
+			const diagnostic3 = warningToDiagnostic(
+				warning3,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			// declaration-block-no-duplicate-properties matches *-block-*, so should NOT
 			// match !*-block-*.
@@ -362,7 +492,12 @@ describe('warningToDiagnostic', () => {
 				},
 			];
 
-			const diagnostic = warningToDiagnostic(warning, logger, undefined, customizations);
+			const diagnostic = warningToDiagnostic(
+				warning,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(logger.warn).toHaveBeenCalledWith('Unknown severity override: unknown-severity');
 			expect(diagnostic).not.toBeNull();
@@ -373,7 +508,12 @@ describe('warningToDiagnostic', () => {
 			const warning = createWarning('test-rule', 'warning');
 			const customizations: RuleCustomization[] = [{ rule: 'test-rule', severity: 'error' }];
 
-			const result = warningToDiagnostic(warning, logger, undefined, customizations);
+			const result = warningToDiagnostic(
+				warning,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(result).not.toBeNull();
 			expect(result!.severity).toBe(DiagnosticSeverity.Error);
@@ -388,8 +528,18 @@ describe('warningToDiagnostic', () => {
 				{ rule: 'color-named', severity: 'default' },
 			];
 
-			const diagnosticError = warningToDiagnostic(warningError, logger, undefined, customizations);
-			const diagnosticWarn = warningToDiagnostic(warningWarn, logger, undefined, customizations);
+			const diagnosticError = warningToDiagnostic(
+				warningError,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
+			const diagnosticWarn = warningToDiagnostic(
+				warningWarn,
+				logger,
+				undefined,
+				compileRuleCustomizations(customizations),
+			);
 
 			expect(diagnosticError).not.toBeNull();
 			expect(diagnosticError!.severity).toBe(DiagnosticSeverity.Error);

--- a/packages/language-server/src/server/stylelint/process-linter-result.ts
+++ b/packages/language-server/src/server/stylelint/process-linter-result.ts
@@ -11,7 +11,7 @@ import {
 	type RuleMetadataSource,
 	type Warning,
 } from './types.js';
-import { warningToDiagnostic } from './warning-to-diagnostic.js';
+import { compileRuleCustomizations, warningToDiagnostic } from './warning-to-diagnostic.js';
 
 /**
  * Returns a unique key for a diagnostic.
@@ -73,11 +73,14 @@ function processSingleLintResult(
 		throw new InvalidOptionError(result.invalidOptionWarnings);
 	}
 
+	const compiledCustomizations = ruleCustomizations?.length
+		? compileRuleCustomizations(ruleCustomizations)
+		: undefined;
 	const diagnostics: LSP.Diagnostic[] = [];
 	const warningsMap = new Map<string, Warning>();
 
 	for (const warning of result.warnings) {
-		const diagnostic = warningToDiagnostic(warning, logger, ruleMetadata, ruleCustomizations);
+		const diagnostic = warningToDiagnostic(warning, logger, ruleMetadata, compiledCustomizations);
 
 		// Only add diagnostic if it wasn't suppressed.
 		if (diagnostic !== null) {

--- a/packages/language-server/src/server/stylelint/warning-to-diagnostic.ts
+++ b/packages/language-server/src/server/stylelint/warning-to-diagnostic.ts
@@ -5,6 +5,50 @@ import type { Logger } from 'winston';
 import type { Warning } from './types.js';
 
 /**
+ * A rule customization with its pattern pre-compiled for efficient matching.
+ */
+export type CompiledRuleCustomization = {
+	severity: SeverityOverride;
+	negated: boolean;
+	exactMatch?: string;
+	pattern?: RegExp;
+};
+
+/**
+ * Compiles an array of rule customizations into a form that can be matched
+ * efficiently against many warnings without rebuilding regexes.
+ */
+export function compileRuleCustomizations(
+	customizations: RuleCustomization[],
+): CompiledRuleCustomization[] {
+	return customizations.map((custom) => {
+		// Check for negation pattern.
+		const isNegated = custom.rule.startsWith('!');
+		const actualPattern = isNegated ? custom.rule.slice(1) : custom.rule;
+
+		// If no wildcard, just use the string for equality checks.
+		if (!actualPattern.includes('*')) {
+			return {
+				severity: custom.severity,
+				negated: isNegated,
+				exactMatch: actualPattern,
+			};
+		}
+
+		// Basic wildcard support for patterns like "color-*" or "*-block-*".
+		const regexSource = actualPattern
+			.replace(/[.+?^${}()|[\]\\]/g, '\\$&') // Escape special regex chars, except for *.
+			.replace(/\*/g, '.*'); // Convert wildcard * to .*
+
+		return {
+			severity: custom.severity,
+			negated: isNegated,
+			pattern: new RegExp(`^${regexSource}$`),
+		};
+	});
+}
+
+/**
  * Converts a severity override value to LSP DiagnosticSeverity. Internal method
  * that only handles direct overrides, not 'upgrade' or 'downgrade'.
  */
@@ -28,45 +72,29 @@ function severityOverrideToLSPSeverity(
  */
 function applySeverityCustomization(
 	warning: Warning,
-	ruleCustomizations: RuleCustomization[] | undefined,
+	compiledCustomizations: CompiledRuleCustomization[] | undefined,
 	logger: Logger,
 ): DiagnosticSeverity | null {
-	if (!ruleCustomizations || ruleCustomizations.length === 0) {
+	if (!compiledCustomizations || compiledCustomizations.length === 0) {
 		// No customizations, use original severity.
 		return DiagnosticSeverity[warning.severity === 'warning' ? 'Warning' : 'Error'];
 	}
 
 	// Find matching customization. Process rules in reverse order so that
 	// subsequent rules have priority over previous ones.
-	let customization: RuleCustomization | undefined;
+	let customization: CompiledRuleCustomization | undefined;
 
-	for (let i = ruleCustomizations.length - 1; i >= 0; i--) {
-		const custom = ruleCustomizations[i];
-		const pattern = custom.rule;
+	for (let i = compiledCustomizations.length - 1; i >= 0; i--) {
+		const compiled = compiledCustomizations[i];
 
-		// Check for negation pattern.
-		const isNegated = pattern.startsWith('!');
-		const actualPattern = isNegated ? pattern.slice(1) : pattern;
-
-		let matches = false;
-
-		// Simple pattern matching, exact match or glob-like matching.
-		if (actualPattern === warning.rule) {
-			matches = true;
-		}
-		// Basic wildcard support for patterns like "color-*" or "*-block-*".
-		else if (actualPattern.includes('*')) {
-			const regexPattern = actualPattern
-				.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // Escape special regex chars.
-				.replace(/\\\*/g, '.*'); // Replace escaped \* with .*
-			const regex = new RegExp(`^${regexPattern}$`);
-
-			matches = regex.test(warning.rule);
-		}
+		const matches =
+			compiled.exactMatch !== undefined
+				? compiled.exactMatch === warning.rule
+				: compiled.pattern!.test(warning.rule);
 
 		// For negated patterns, invert the match result.
-		if (isNegated ? !matches : matches) {
-			customization = custom;
+		if (compiled.negated ? !matches : matches) {
+			customization = compiled;
 			break;
 		}
 	}
@@ -151,9 +179,9 @@ export function warningToDiagnostic(
 	warning: Warning,
 	logger: Logger,
 	ruleMetadata?: stylelint.LinterResult['ruleMetadata'],
-	ruleCustomizations?: RuleCustomization[],
+	compiledCustomizations?: CompiledRuleCustomization[],
 ): Diagnostic | null {
-	const severity = applySeverityCustomization(warning, ruleCustomizations, logger);
+	const severity = applySeverityCustomization(warning, compiledCustomizations, logger);
 
 	// If severity is null, the diagnostic should be suppressed.
 	if (severity === null) {


### PR DESCRIPTION
Pre-compile regexes used for matching rule severity customizations.

Wildcard patterns in `stylelint.rules.customizations` were getting compiled into a new `RegExp` for every single Stylelint warning in every lint result. So for N warnings and M wildcard customization rules, N x M identical regex compilations were being performed per lint cycle. Here, they get pre-compiled so that compilation is only performed once per pattern. (And also a minor though insignificant change to how asterisks were being escaped then converted, which I don't even really know why I wrote it that way to begin with.)