### PR TITLE
perf: cancel in-flight worker requests

### DIFF
--- a/.changeset/late-doors-run.md
+++ b/.changeset/late-doors-run.md
@@ -1,0 +1,6 @@
+---
+"@stylelint/language-server": patch
+"@stylelint/vscode-stylelint": patch
+---
+
+Fixed: stale worker requests continuing to run after becoming obsolete

--- a/packages/language-server/src/server/services/lsp/__tests__/validator.service.test.ts
+++ b/packages/language-server/src/server/services/lsp/__tests__/validator.service.test.ts
@@ -24,6 +24,7 @@ import { getLanguageServerServiceMetadata } from '../../../decorators.js';
 import type { LintDiagnostics } from '../../../stylelint/index.js';
 import { lspConnectionToken, textDocumentsToken, UriModuleToken } from '../../../tokens.js';
 import { CommandId } from '../../../types.js';
+import { StylelintRequestCancelledError } from '../../../worker/worker-process.js';
 import { DocumentDiagnosticsService } from '../../documents/document-diagnostics.service.js';
 import { type LoggingService, loggingServiceToken } from '../../infrastructure/logging.service.js';
 import { NotificationService } from '../../infrastructure/notification.service.js';
@@ -541,6 +542,98 @@ describe('ValidatorLspModule', () => {
 			await service.clearAllProblems();
 
 			expect(connection.sendDiagnosticsCalls).toHaveLength(0);
+		});
+	});
+
+	describe('cancellation', () => {
+		it('should pass an AbortSignal to the runner', async () => {
+			const document = setDocument();
+			const lintDiagnostics = [createDiagnostic('lint')];
+
+			options.setValidateLanguages(['css']);
+			runner.setLintResult(document.uri, createDiagnosticsResult(lintDiagnostics));
+
+			await service.handleDocumentOpened(createChangeEvent(document));
+
+			expect(runner.lintCalls).toHaveLength(1);
+			expect(runner.lintCalls[0].signal).toBeInstanceOf(AbortSignal);
+			expect(runner.lintCalls[0].signal?.aborted).toBe(false);
+		});
+
+		it('should abort the previous validation when the same document is re-validated', async () => {
+			const document = setDocument();
+			const lintDiagnostics = [createDiagnostic('lint')];
+
+			options.setValidateLanguages(['css']);
+
+			const releaseLint = runner.setDeferredLintResult(
+				document.uri,
+				createDiagnosticsResult(lintDiagnostics),
+			);
+
+			const firstValidation = service.handleDocumentOpened(createChangeEvent(document));
+
+			await flushPromises();
+
+			expect(runner.lintCalls).toHaveLength(1);
+
+			const firstSignal = runner.lintCalls[0].signal;
+
+			expect(firstSignal?.aborted).toBe(false);
+
+			runner.setLintResult(document.uri, createDiagnosticsResult(lintDiagnostics));
+
+			const secondValidation = service.handleDocumentOpened(createChangeEvent(document));
+
+			await flushPromises();
+
+			expect(firstSignal?.aborted).toBe(true);
+
+			releaseLint();
+			await firstValidation;
+			await secondValidation;
+		});
+
+		it('should not send diagnostics when a lint is cancelled', async () => {
+			const document = setDocument();
+
+			options.setValidateLanguages(['css']);
+			runner.setLintError(document.uri, new StylelintRequestCancelledError());
+
+			await service.handleDocumentOpened(createChangeEvent(document));
+
+			expect(connection.sendDiagnosticsCalls).toHaveLength(0);
+			expect(connection.windowMessages).toHaveLength(0);
+			expect(logger.debug).toHaveBeenCalledWith('Lint cancelled', {
+				uri: document.uri,
+			});
+		});
+
+		it('clearAllProblems should abort in-flight validations', async () => {
+			const document = setDocument();
+			const lintDiagnostics = [createDiagnostic('lint')];
+
+			options.setValidateLanguages(['css']);
+
+			const releaseLint = runner.setDeferredLintResult(
+				document.uri,
+				createDiagnosticsResult(lintDiagnostics),
+			);
+
+			const validation = service.handleDocumentOpened(createChangeEvent(document));
+
+			await flushPromises();
+
+			const signal = runner.lintCalls[0].signal;
+
+			expect(signal?.aborted).toBe(false);
+
+			await service.clearAllProblems();
+
+			expect(signal?.aborted).toBe(true);
+
+			releaseLint();
+			await validation;
 		});
 	});
 });

--- a/packages/language-server/src/server/services/lsp/validator.service.ts
+++ b/packages/language-server/src/server/services/lsp/validator.service.ts
@@ -18,6 +18,7 @@ import {
 import type { LintDiagnostics } from '../../stylelint/index.js';
 import { lspConnectionToken, textDocumentsToken, UriModuleToken } from '../../tokens.js';
 import { CommandId, Status, StatusNotification } from '../../types.js';
+import { StylelintRequestCancelledError } from '../../worker/worker-process.js';
 import { DocumentDiagnosticsService } from '../documents/document-diagnostics.service.js';
 import { type LoggingService, loggingServiceToken } from '../infrastructure/logging.service.js';
 import { StylelintRunnerService } from '../stylelint-runtime/stylelint-runner.service.js';
@@ -52,6 +53,7 @@ export class ValidatorLspService {
 	#publishedUris = new Set<string>();
 	#debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 	#pendingValidations = new Map<string, Promise<void>>();
+	#abortControllers = new Map<string, AbortController>();
 
 	constructor(
 		documents: TextDocuments<TextDocument>,
@@ -150,83 +152,115 @@ export class ValidatorLspService {
 			clearTimeout(timer);
 			this.#debounceTimers.delete(uri);
 		}
+
+		this.#abortValidation(uri);
+	}
+
+	#abortValidation(uri: string): void {
+		const controller = this.#abortControllers.get(uri);
+
+		if (controller) {
+			controller.abort();
+			this.#abortControllers.delete(uri);
+		}
 	}
 
 	async #validate(document: TextDocument): Promise<void> {
+		this.#abortValidation(document.uri);
+
+		const controller = new AbortController();
+
+		this.#abortControllers.set(document.uri, controller);
+
 		const versionBefore = document.version;
 
-		if (!(await this.#shouldValidate(document))) {
-			if (this.#diagnostics.getDiagnostics(document.uri).length > 0) {
-				this.#logger?.debug('Document should not be validated, clearing diagnostics', {
-					uri: document.uri,
-					language: document.languageId,
-				});
-				await this.#clearDiagnostics(document);
-			} else {
-				this.#logger?.debug('Document should not be validated, ignoring', {
-					uri: document.uri,
-					language: document.languageId,
-				});
+		try {
+			if (!(await this.#shouldValidate(document))) {
+				if (this.#diagnostics.getDiagnostics(document.uri).length > 0) {
+					this.#logger?.debug('Document should not be validated, clearing diagnostics', {
+						uri: document.uri,
+						language: document.languageId,
+					});
+					await this.#clearDiagnostics(document);
+				} else {
+					this.#logger?.debug('Document should not be validated, ignoring', {
+						uri: document.uri,
+						language: document.languageId,
+					});
+				}
+
+				return;
 			}
 
-			return;
-		}
+			const result = await this.#lintDocument(document, controller.signal);
 
-		const result = await this.#lintDocument(document);
+			if (!result) {
+				this.#logger?.debug('No lint result, ignoring', { uri: document.uri });
 
-		if (!result) {
-			this.#logger?.debug('No lint result, ignoring', { uri: document.uri });
+				return;
+			}
 
-			return;
-		}
+			// If the document was edited while the lint was running, discard the
+			// stale result. A new validation will be triggered by the edit.
+			const currentDocument = this.#documents.get(document.uri);
 
-		// If the document was edited while the lint was running, discard the
-		// stale result. A new validation will be triggered by the edit.
-		const currentDocument = this.#documents.get(document.uri);
+			if (currentDocument && currentDocument.version !== versionBefore) {
+				this.#logger?.debug('Discarding stale lint result', {
+					uri: document.uri,
+					lintedVersion: versionBefore,
+					currentVersion: currentDocument.version,
+				});
 
-		if (currentDocument && currentDocument.version !== versionBefore) {
-			this.#logger?.debug('Discarding stale lint result', {
-				uri: document.uri,
-				lintedVersion: versionBefore,
-				currentVersion: currentDocument.version,
-			});
+				return;
+			}
 
-			return;
-		}
-
-		this.#logger?.debug('Sending diagnostics', {
-			uri: document.uri,
-			diagnostics: result.diagnostics,
-		});
-
-		try {
-			await this.#connection.sendDiagnostics({
+			this.#logger?.debug('Sending diagnostics', {
 				uri: document.uri,
 				diagnostics: result.diagnostics,
 			});
-			this.#diagnostics.set(document, result.diagnostics, result);
-			this.#publishedUris.add(document.uri);
-			this.#logger?.debug('Diagnostics sent', { uri: document.uri });
-			this.#sendStatusNotification(document.uri, Status.ok);
-		} catch (error) {
-			displayError(this.#connection, error);
-			this.#logger?.error('Failed to send diagnostics', {
-				uri: document.uri,
-				error,
-			});
-			this.#sendStatusNotification(document.uri, Status.error);
+
+			try {
+				await this.#connection.sendDiagnostics({
+					uri: document.uri,
+					diagnostics: result.diagnostics,
+				});
+				this.#diagnostics.set(document, result.diagnostics, result);
+				this.#publishedUris.add(document.uri);
+				this.#logger?.debug('Diagnostics sent', { uri: document.uri });
+				this.#sendStatusNotification(document.uri, Status.ok);
+			} catch (error) {
+				displayError(this.#connection, error);
+				this.#logger?.error('Failed to send diagnostics', {
+					uri: document.uri,
+					error,
+				});
+				this.#sendStatusNotification(document.uri, Status.error);
+			}
+		} finally {
+			if (this.#abortControllers.get(document.uri) === controller) {
+				this.#abortControllers.delete(document.uri);
+			}
 		}
 	}
 
-	async #lintDocument(document: TextDocument): Promise<LintDiagnostics | undefined> {
+	async #lintDocument(
+		document: TextDocument,
+		signal?: AbortSignal,
+	): Promise<LintDiagnostics | undefined> {
 		this.#logger?.debug('Linting document', { uri: document.uri });
 
 		try {
 			const options = await this.#options.getOptions(document.uri);
-			const results = await this.#runner.lintDocument(document, {}, options);
+			const results = await this.#runner.lintDocument(document, {}, options, signal);
 
 			return results;
 		} catch (error) {
+			if (error instanceof StylelintRequestCancelledError) {
+				this.#logger?.debug('Lint cancelled', { uri: document.uri });
+
+				return undefined;
+			}
+
 			displayError(this.#connection, error);
 			this.#logger?.error('Error running lint', { uri: document.uri, error });
 			this.#sendStatusNotification(document.uri, Status.error);
@@ -249,6 +283,18 @@ export class ValidatorLspService {
 
 	@command(CommandId.ClearAllProblems)
 	async clearAllProblems(): Promise<void> {
+		for (const timer of this.#debounceTimers.values()) {
+			clearTimeout(timer);
+		}
+
+		this.#debounceTimers.clear();
+
+		for (const controller of this.#abortControllers.values()) {
+			controller.abort();
+		}
+
+		this.#abortControllers.clear();
+
 		for (const uri of this.#publishedUris) {
 			this.#diagnostics.clear(uri);
 			await this.#connection.sendDiagnostics({ uri, diagnostics: [] });

--- a/packages/language-server/src/server/services/stylelint-runtime/__tests__/workspace-stylelint.service.test.ts
+++ b/packages/language-server/src/server/services/stylelint-runtime/__tests__/workspace-stylelint.service.test.ts
@@ -142,11 +142,14 @@ describe('WorkspaceStylelintService', () => {
 			},
 			expect.any(Function),
 		);
-		expect(worker.lint).toHaveBeenCalledWith({
-			options: request.options,
-			stylelintPath: undefined,
-			runnerOptions: request.runnerOptions,
-		});
+		expect(worker.lint).toHaveBeenCalledWith(
+			{
+				options: request.options,
+				stylelintPath: undefined,
+				runnerOptions: request.runnerOptions,
+			},
+			undefined,
+		);
 	});
 
 	test('logs debug information when Stylelint is not found during lint', async () => {
@@ -187,11 +190,14 @@ describe('WorkspaceStylelintService', () => {
 			}),
 		).resolves.toBe(resolveResult);
 
-		expect(worker.resolve).toHaveBeenCalledWith({
-			stylelintPath: 'stylelint',
-			codeFilename: undefined,
-			runnerOptions: {} as RunnerOptions,
-		});
+		expect(worker.resolve).toHaveBeenCalledWith(
+			{
+				stylelintPath: 'stylelint',
+				codeFilename: undefined,
+				runnerOptions: {} as RunnerOptions,
+			},
+			undefined,
+		);
 	});
 
 	test('disposes caches and workers for a workspace', () => {

--- a/packages/language-server/src/server/services/stylelint-runtime/stylelint-runner.service.ts
+++ b/packages/language-server/src/server/services/stylelint-runtime/stylelint-runner.service.ts
@@ -117,6 +117,7 @@ export class StylelintRunnerService {
 		document: TextDocument,
 		linterOptions: stylelint.LinterOptions = {},
 		runnerOptions: RunnerOptions = {},
+		signal?: AbortSignal,
 	): Promise<LintDiagnostics> {
 		const workspaceFolder = await this.#workspaceFolderService.getWorkspaceFolder(
 			this.#connection,
@@ -139,6 +140,7 @@ export class StylelintRunnerService {
 			options,
 			runnerOptions,
 			resolvedStylelintPath,
+			signal,
 		);
 
 		if (diagnostics) {
@@ -546,6 +548,7 @@ export class StylelintRunnerService {
 		options: stylelint.LinterOptions,
 		runnerOptions: RunnerOptions,
 		stylelintPath?: string,
+		signal?: AbortSignal,
 	): Promise<LintDiagnostics | undefined> {
 		if (!this.#workspaceService) {
 			return undefined;
@@ -582,12 +585,15 @@ export class StylelintRunnerService {
 			const result =
 				lintOptions === options && cachedResult
 					? cachedResult
-					: await this.#workspaceService.lint({
-							workspaceFolder: lintWorkspaceFolder,
-							options: lintOptions,
-							stylelintPath,
-							runnerOptions,
-						});
+					: await this.#workspaceService.lint(
+							{
+								workspaceFolder: lintWorkspaceFolder,
+								options: lintOptions,
+								stylelintPath,
+								runnerOptions,
+							},
+							signal,
+						);
 
 			if (!result) {
 				throw new StylelintNotFoundError();

--- a/packages/language-server/src/server/services/stylelint-runtime/workspace-stylelint.service.ts
+++ b/packages/language-server/src/server/services/stylelint-runtime/workspace-stylelint.service.ts
@@ -66,7 +66,10 @@ export class WorkspaceStylelintService {
 		this.#workerRegistry = workerRegistry;
 	}
 
-	async lint(request: WorkspaceLintRequest): Promise<WorkerLintResult | undefined> {
+	async lint(
+		request: WorkspaceLintRequest,
+		signal?: AbortSignal,
+	): Promise<WorkerLintResult | undefined> {
 		const pnpConfig = await this.#pnpConfigurationCache.findConfiguration(
 			request.options.codeFilename,
 		);
@@ -90,11 +93,14 @@ export class WorkspaceStylelintService {
 					environmentKey,
 				},
 				async (worker) =>
-					await worker.lint({
-						options: request.options,
-						stylelintPath: request.stylelintPath,
-						runnerOptions: request.runnerOptions,
-					}),
+					await worker.lint(
+						{
+							options: request.options,
+							stylelintPath: request.stylelintPath,
+							runnerOptions: request.runnerOptions,
+						},
+						signal,
+					),
 			);
 		} catch (error) {
 			if (error instanceof StylelintNotFoundError) {
@@ -107,7 +113,10 @@ export class WorkspaceStylelintService {
 		}
 	}
 
-	async resolve(request: WorkspaceResolveRequest): Promise<WorkerResolveResult | undefined> {
+	async resolve(
+		request: WorkspaceResolveRequest,
+		signal?: AbortSignal,
+	): Promise<WorkerResolveResult | undefined> {
 		const pnpConfig = await this.#pnpConfigurationCache.findConfiguration(request.codeFilename);
 		const workerRoot = await this.#packageRootCache.determineWorkerRoot(
 			request.workspaceFolder,
@@ -129,11 +138,14 @@ export class WorkspaceStylelintService {
 					environmentKey,
 				},
 				async (worker) =>
-					await worker.resolve({
-						stylelintPath: request.stylelintPath,
-						codeFilename: request.codeFilename,
-						runnerOptions: request.runnerOptions,
-					}),
+					await worker.resolve(
+						{
+							stylelintPath: request.stylelintPath,
+							codeFilename: request.codeFilename,
+							runnerOptions: request.runnerOptions,
+						},
+						signal,
+					),
 			);
 		} catch (error) {
 			if (error instanceof StylelintNotFoundError) {
@@ -148,6 +160,7 @@ export class WorkspaceStylelintService {
 
 	async resolveConfig(
 		request: WorkspaceResolveConfigRequest,
+		signal?: AbortSignal,
 	): Promise<WorkerResolveConfigResult | undefined> {
 		const pnpConfig = await this.#pnpConfigurationCache.findConfiguration(request.filePath);
 		const workerRoot = await this.#packageRootCache.determineWorkerRoot(
@@ -170,11 +183,14 @@ export class WorkspaceStylelintService {
 					environmentKey,
 				},
 				async (worker) =>
-					await worker.resolveConfig({
-						filePath: request.filePath,
-						stylelintPath: request.stylelintPath,
-						runnerOptions: request.runnerOptions,
-					}),
+					await worker.resolveConfig(
+						{
+							filePath: request.filePath,
+							stylelintPath: request.stylelintPath,
+							runnerOptions: request.runnerOptions,
+						},
+						signal,
+					),
 			);
 		} catch (error) {
 			if (error instanceof StylelintNotFoundError) {

--- a/packages/language-server/src/server/worker/types.ts
+++ b/packages/language-server/src/server/worker/types.ts
@@ -58,6 +58,10 @@ export type WorkerRequest =
 	| {
 			id: string;
 			type: 'shutdown';
+	  }
+	| {
+			id: string;
+			type: 'cancel';
 	  };
 
 export type SerializedWorkerError = {

--- a/packages/language-server/src/server/worker/worker-entry.ts
+++ b/packages/language-server/src/server/worker/worker-entry.ts
@@ -58,6 +58,13 @@ const state: {
 	version?: string;
 } = {};
 
+/**
+ * Tracks IDs of requests that were cancelled by the parent process. When a
+ * handler finishes for a cancelled request, it should skip sending the result
+ * back over the process channel.
+ */
+const cancelledRequests = new Set<string>();
+
 const createLinterResultSubset = (linterResult: stylelint.LinterResult): LinterResult => {
 	const subset: LinterResult = {
 		results: (Array.isArray(linterResult.results) ? linterResult.results : []).map(
@@ -357,6 +364,10 @@ async function handleResolve(
 		request.payload.runnerOptions,
 	);
 
+	if (cancelledRequests.delete(request.id)) {
+		return;
+	}
+
 	if (!state.resolvedPath || !state.entryPath) {
 		throw createNotFoundError();
 	}
@@ -384,11 +395,20 @@ async function handleLint(
 		request.payload.runnerOptions,
 	);
 
+	if (cancelledRequests.delete(request.id)) {
+		return;
+	}
+
 	if (!state.stylelint || !state.resolvedPath) {
 		throw createNotFoundError();
 	}
 
 	const linterResult = await state.stylelint.lint(request.payload.options);
+
+	if (cancelledRequests.delete(request.id)) {
+		return;
+	}
+
 	const subsetResult = createLinterResultSubset(linterResult);
 
 	sendMessage({
@@ -414,6 +434,10 @@ async function handleResolveConfig(
 		request.payload.runnerOptions,
 	);
 
+	if (cancelledRequests.delete(request.id)) {
+		return;
+	}
+
 	if (!state.stylelint || !state.resolvedPath) {
 		throw createNotFoundError();
 	}
@@ -427,6 +451,10 @@ async function handleResolveConfig(
 
 	if (typeof resolveConfigFn === 'function') {
 		config = await resolveConfigFn(request.payload.filePath);
+	}
+
+	if (cancelledRequests.delete(request.id)) {
+		return;
 	}
 
 	sendMessage({
@@ -470,6 +498,11 @@ const handleMessage = async (request?: WorkerRequest): Promise<void> => {
 				process.exitCode = 0;
 
 				return;
+			}
+
+			case 'cancel': {
+				cancelledRequests.add(request.id);
+				break;
 			}
 
 			default:

--- a/packages/language-server/src/server/worker/worker-process.ts
+++ b/packages/language-server/src/server/worker/worker-process.ts
@@ -131,6 +131,13 @@ export class StylelintWorkerUnavailableError extends Error {
 	}
 }
 
+export class StylelintRequestCancelledError extends Error {
+	constructor(message?: string) {
+		super(message ?? 'The lint request was cancelled.');
+		this.name = 'StylelintRequestCancelledError';
+	}
+}
+
 type WorkerSuccessResponse = Extract<WorkerResponse, { success: true }>;
 type PendingRequest = {
 	resolve: (value: WorkerSuccessResponse['result']) => void;
@@ -166,20 +173,27 @@ export class StylelintWorkerProcess {
 		return this.#disposed;
 	}
 
-	async lint(payload: WorkerLintPayload): Promise<WorkerLintResult> {
-		const result = (await this.#sendRequest('lint', payload)) as WorkerLintResult;
+	async lint(payload: WorkerLintPayload, signal?: AbortSignal): Promise<WorkerLintResult> {
+		const result = (await this.#sendRequest('lint', payload, signal)) as WorkerLintResult;
 
 		return result;
 	}
 
-	async resolve(payload: WorkerResolvePayload): Promise<WorkerResolveResult> {
-		const result = (await this.#sendRequest('resolve', payload)) as WorkerResolveResult;
+	async resolve(payload: WorkerResolvePayload, signal?: AbortSignal): Promise<WorkerResolveResult> {
+		const result = (await this.#sendRequest('resolve', payload, signal)) as WorkerResolveResult;
 
 		return result;
 	}
 
-	async resolveConfig(payload: WorkerResolveConfigPayload): Promise<WorkerResolveConfigResult> {
-		const result = (await this.#sendRequest('resolveConfig', payload)) as WorkerResolveConfigResult;
+	async resolveConfig(
+		payload: WorkerResolveConfigPayload,
+		signal?: AbortSignal,
+	): Promise<WorkerResolveConfigResult> {
+		const result = (await this.#sendRequest(
+			'resolveConfig',
+			payload,
+			signal,
+		)) as WorkerResolveConfigResult;
 
 		return result;
 	}
@@ -217,8 +231,13 @@ export class StylelintWorkerProcess {
 
 	async #sendRequest(
 		type: WorkerRequest['type'],
-		payload?: WorkerLintPayload | WorkerResolvePayload,
+		payload?: WorkerLintPayload | WorkerResolvePayload | WorkerResolveConfigPayload,
+		signal?: AbortSignal,
 	): Promise<WorkerSuccessResponse['result']> {
+		if (signal?.aborted) {
+			throw new StylelintRequestCancelledError();
+		}
+
 		this.#ensureChild();
 
 		const id = createRequestId();
@@ -230,13 +249,27 @@ export class StylelintWorkerProcess {
 				return;
 			}
 
+			const onAbort = (): void => {
+				const pending = this.#pending.get(id);
+
+				if (pending) {
+					this.#pending.delete(id);
+					this.#sendCancelMessage(id);
+					pending.reject(new StylelintRequestCancelledError());
+				}
+			};
+
+			signal?.addEventListener('abort', onAbort, { once: true });
+
 			this.#pending.set(id, {
 				resolve: (value) => {
+					signal?.removeEventListener('abort', onAbort);
 					this.#pending.delete(id);
 					this.#resetIdleTimer();
 					resolve(value);
 				},
 				reject: (error) => {
+					signal?.removeEventListener('abort', onAbort);
 					this.#pending.delete(id);
 					reject(error);
 				},
@@ -253,6 +286,16 @@ export class StylelintWorkerProcess {
 
 			this.#child.send(request);
 		});
+	}
+
+	#sendCancelMessage(id: string): void {
+		if (this.#child && !this.#disposed) {
+			try {
+				this.#child.send({ id, type: 'cancel' } as WorkerRequest);
+			} catch {
+				// Worker may have already exited.
+			}
+		}
 	}
 
 	#ensureChild(): void {

--- a/test/helpers/stubs/stylelint-runner-service.ts
+++ b/test/helpers/stubs/stylelint-runner-service.ts
@@ -15,6 +15,7 @@ export type StylelintRunnerStub = Pick<
 		document: TextDocument;
 		linterOptions?: unknown;
 		runnerOptions?: RunnerOptions;
+		signal?: AbortSignal;
 	}>;
 	resolveCalls: string[];
 	lintWorkspaceFolderCalls: Array<{
@@ -26,11 +27,18 @@ export type StylelintRunnerStub = Pick<
 	setResolution(uri: string, result: StylelintResolutionResult | undefined): void;
 	setLintWorkspaceFolderResult(result: MultiFileLintDiagnostics): void;
 	setLintWorkspaceFolderError(error: unknown): void;
+	/**
+	 * Makes lintDocument return a promise that won't resolve until the returned
+	 * callback is invoked.
+	 */
+	setDeferredLintResult(uri: string, result: LintDiagnostics | undefined): () => void;
 };
 
 export function createStylelintRunnerStub(): StylelintRunnerStub {
 	const lintResults = new Map<string, LintDiagnostics | undefined>();
 	const lintErrors = new Map<string, unknown>();
+	const deferredResolvers = new Map<string, () => void>();
+	const deferredResults = new Map<string, LintDiagnostics | undefined>();
 	const resolutions = new Map<string, StylelintResolutionResult | undefined>();
 	const lintCalls: StylelintRunnerStub['lintCalls'] = [];
 	const resolveCalls: string[] = [];
@@ -57,12 +65,28 @@ export function createStylelintRunnerStub(): StylelintRunnerStub {
 		setLintWorkspaceFolderError: (error: unknown) => {
 			workspaceFolderError = error;
 		},
+		setDeferredLintResult: (uri: string, result: LintDiagnostics | undefined): (() => void) => {
+			deferredResolvers.set(uri, () => {});
+			deferredResults.set(uri, result);
+
+			// Return callback that releases the lint.
+			return () => {
+				const r = deferredResolvers.get(uri);
+
+				if (r) {
+					deferredResolvers.delete(uri);
+					deferredResults.delete(uri);
+					r();
+				}
+			};
+		},
 		async lintDocument(
 			document: TextDocument,
 			linterOptions?: unknown,
 			runnerOptions?: RunnerOptions,
+			signal?: AbortSignal,
 		) {
-			lintCalls.push({ document, linterOptions, runnerOptions });
+			lintCalls.push({ document, linterOptions, runnerOptions, signal });
 
 			if (lintErrors.has(document.uri)) {
 				const error = lintErrors.get(document.uri);
@@ -72,6 +96,20 @@ export function createStylelintRunnerStub(): StylelintRunnerStub {
 				}
 
 				throw new Error(String(error));
+			}
+
+			// If a deferred result is registered, wait for it to be released.
+			if (deferredResolvers.has(document.uri)) {
+				await new Promise<void>((resolve) => {
+					const existingResolve = deferredResolvers.get(document.uri)!;
+
+					deferredResolvers.set(document.uri, () => {
+						existingResolve();
+						resolve();
+					});
+				});
+
+				return deferredResults.get(document.uri) as unknown as LintDiagnostics;
 			}
 
 			return lintResults.get(document.uri) as unknown as LintDiagnostics;


### PR DESCRIPTION
Cancel in-flight worker requests that have become obsolete.

When a new validation is triggered for a document, via re-edit, config change, watched file change, or otherwise, any previous worker request for that document was left to run to completion in the worker process, even though its results would be discarded. With rapid edits or bulk operations, multiple stale requests could pile up, wasting CPU time in the worker and delaying the result the user actually cares about.

This adds an AbortController-based cancellation system that propagates from the validator service through the runner and workspace service, across IPC into the worker process. When a validation becomes obsolete, the in-flight request is aborted immediately, freeing the worker to handle the current request sooner.